### PR TITLE
[Chore] ecr 배포 워크플로우

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Build and Push AI Server to ECR
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: nunchi-ai
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build and push Docker image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: nunchi-ai
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           IMAGE_TAG: latest
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ PLAN.md
 RESULT.md
 reference/
 *.docx
+.env
+*.pem
+.venv/
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,3 @@ PLAN.md
 RESULT.md
 reference/
 *.docx
-.env
-*.pem
-.venv/
-__pycache__/
-*.pyc

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# 환경에 따라 달라지는 Maven 홈 디렉터리
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/NUNCHI-AI.iml
+++ b/.idea/NUNCHI-AI.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.11 (NUNCHI-AI)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8" />
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11 (NUNCHI-AI)" />
+  </component>
+  <component name="CodeInsightWorkspaceSettings">
+    <option name="optimizeImportsOnTheFly" value="true" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/NUNCHI-AI.iml" filepath="$PROJECT_DIR$/.idea/NUNCHI-AI.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #7 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- AI 서버 Dockerfile을 추가하여 FastAPI 서버를 컨테이너 이미지로 빌드할 수 있도록 구성했습니다.
- 로컬 환경에서 `nunchi-ai:latest` 이미지 빌드 및 컨테이너 실행을 검증했습니다.
- AWS ECR에 `nunchi-ai:latest` 이미지를 수동 push하여 이미지 저장소 연동을 확인했습니다.
- EC2 `docker-compose` 환경에 AI 서버 컨테이너를 추가하고, Spring 서버와 동일 네트워크에서 통신할 수 있도록 구성했습니다.
- Spring 서버가 AI 서버를 `http://ai:8000` 주소로 호출할 수 있도록 `FASTAPI_BASE_URL` 환경변수를 추가했습니다.
- EC2 환경에서 AI 서버 `/health` 응답, Spring 서버 Swagger 접근, PostgreSQL/Redis 컨테이너 연동을 확인했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 컨테이너 내부 통신에서는 `localhost`를 사용하면 안 됩니다.
  - Spring → AI 서버: `http://ai:8000`
  - Spring → PostgreSQL: `jdbc:postgresql://postgres:5432/nunchi`
- AI 서버는 외부 포트를 직접 개방하지 않고, compose 내부 네트워크에서만 접근하도록 구성했습니다.
- 현재 ECR push는 수동으로 검증한 상태이며, GitHub Actions 기반 자동 push는 후속 작업으로 진행할 예정입니다.
- `.env`, AWS Access Key, OpenAI API Key, `.pem` 파일은 Git에 올리면 안 됩니다.
- Dockerfile, requirements.txt, docker-compose 설정 파일은 배포 재현을 위해 Git에 포함해도 됩니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

- 별도 Postman 테스트는 아직 진행하지 않았습니다.
- 대신 아래 항목으로 배포 및 연결 상태를 검증했습니다.
  - `curl http://ai:8000/health` 내부 네트워크 응답 확인
  - `FASTAPI_BASE_URL=http://ai:8000` 환경변수 주입 확인
  - `http://43.201.20.11:8080/swagger-ui/index.html` 접속 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Docker 기반 실행 이미지 추가로 컨테이너화 지원 도입
* **Chores**
  * main 브랜치 푸시 시 이미지 빌드·푸시 자동화하는 배포 워크플로우 추가
  * 개발 환경(IDE) 설정 파일 정리 및 로컬 메타데이터 무시 규칙(.gitignore) 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->