### PR TITLE
[Feat] 메뉴 필터 Tool 및 복합 추천 쿼리 지원 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,13 @@
       "Bash(pip3 install:*)",
       "Bash(python3:*)",
       "Bash(git add:*)",
-      "Bash(git commit -m ':*)"
+      "Bash(git commit -m ':*)",
+      "WebFetch(domain:github.com)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)",
+      "Bash(git commit *)",
+      "Bash(gh api *)",
+      "Bash(python *)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ env/
 CLAUDE.md
 PLAN.md
 RESULT.md
+REQUEST.md
 reference/
 *.docx

--- a/core/config.py
+++ b/core/config.py
@@ -7,15 +7,17 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     # Spring 백엔드
     spring_base_url: str = "http://localhost:8080"
-    spring_timeout: int = Field(default=5, ge=1)  # 최소 1초 이상
+    spring_timeout: int = Field(default=5, ge=1)
 
-    # Gemini
-    gemini_api_key: str = Field(min_length=1)  # 빈 문자열 거부
-    gemini_model: str = "gemini-2.0-flash"
+    # OpenAI
+    openai_api_key: str = Field(min_length=1, alias="OPEN_API_KEY")
+    openai_model: str = "gpt-4o-mini"
 
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        populate_by_name=True,
+        extra="ignore",
     )
 
 

--- a/domain/menu.py
+++ b/domain/menu.py
@@ -31,8 +31,8 @@ class OptionGroup(BaseModel):
 
     group_id: int = Field(alias="groupId")
     group_name: str = Field(alias="groupName")
-    is_required: bool = Field(alias="isRequired")
-    max_select: int = Field(alias="maxSelect")
+    is_required: bool = Field(default=False, alias="isRequired")
+    max_select: int = Field(default=1, alias="maxSelect")
     options: list[Option] = Field(default_factory=list)
 
 

--- a/domain/menu.py
+++ b/domain/menu.py
@@ -81,6 +81,25 @@ class TopMenuSummary(BaseModel):
     is_sold_out: bool = Field(alias="isSoldOut")
 
 
+class FilterMenuResult(BaseModel):
+    """GET /api/menus/filter 응답 항목 (nutrition 포함)"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    menu_id: int = Field(alias="menuId")
+    name: str
+    price: int
+    category_id: Optional[int] = Field(default=None, alias="categoryId")
+    image_url: Optional[str] = Field(default=None, alias="imageUrl")
+    spicy_level: int = Field(default=0, alias="spicyLevel")
+    temperature_type: str = Field(default="HOT", alias="temperatureType")
+    vegetarian_type: str = Field(default="NONE", alias="vegetarianType")
+    season_recommended: str = Field(default="ALL", alias="seasonRecommended")
+    allergies: list[str] = Field(default_factory=list)
+    is_sold_out: bool = Field(alias="isSoldOut")
+    nutrition: Optional[Nutrition] = None
+
+
 class MenuDetail(BaseModel):
     """GET /api/menus/{menuId} 응답 (상세 + 옵션 + 영양 + 알레르기)"""
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -19,7 +19,7 @@ from mcp.tools.cart_tools import (
     remove_cart_item,
     update_cart_item,
 )
-from mcp.tools.menu_tools import get_categories, get_menu_detail, get_menus, get_top_menus
+from mcp.tools.menu_tools import filter_menus, get_categories, get_menu_detail, get_menus, get_top_menus
 from mcp.tools.order_tools import confirm_order
 from mcp.tools.payment_tools import request_payment
 from mcp.tools.session_tools import complete_session, save_tool_log
@@ -130,6 +130,12 @@ def make_recommend_tools(spring: SpringAdapter, session_id: int) -> list:
         return result
 
     @tool
+    async def tool_get_categories() -> str:
+        """카테고리 목록(categoryId + name)을 조회한다. 카테고리 이름으로 메뉴를 찾기 전에 반드시 호출해 categoryId를 확인한다."""
+        result = json.dumps([c.model_dump() for c in await get_categories(spring)], ensure_ascii=False)
+        return await _log_tool("get_categories", {}, result)
+
+    @tool
     async def tool_get_all_menus() -> str:
         """전체 메뉴 목록을 반환한다. 칼로리·매운맛·알레르기·채식·계절·온도 기준 추천 시 사용한다."""
         result = json.dumps([m.model_dump() for m in await get_menus(spring)], ensure_ascii=False)
@@ -149,13 +155,67 @@ def make_recommend_tools(spring: SpringAdapter, session_id: int) -> list:
 
     @tool
     async def tool_get_menu_detail_recommend(menu_id: int) -> str:
-        """추천할 메뉴의 상세 정보를 조회한다."""
+        """추천할 메뉴의 상세 정보(nutrition 포함)를 조회한다. top 메뉴 중 영양소 비교가 필요할 때 사용한다."""
         result = json.dumps((await get_menu_detail(spring, menu_id)).model_dump(), ensure_ascii=False)
         return await _log_tool("get_menu_detail", {"menu_id": menu_id}, result)
 
+    @tool
+    async def tool_filter_menus(
+        max_calorie: Optional[int] = None,
+        min_calorie: Optional[int] = None,
+        min_protein: Optional[float] = None,
+        max_sodium: Optional[float] = None,
+        max_spicy_level: Optional[int] = None,
+        min_spicy_level: Optional[int] = None,
+        min_price: Optional[int] = None,
+        max_price: Optional[int] = None,
+        temperature_type: Optional[str] = None,
+        vegetarian_type: Optional[str] = None,
+        season: Optional[str] = None,
+        category_id: Optional[int] = None,
+        exclude_allergies: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> str:
+        """조건에 맞는 메뉴를 필터링해 반환한다. nutrition 포함. 파라미터는 모두 Optional.
+
+        - max_calorie / min_calorie: 칼로리 범위 (kcal)
+        - min_protein: 단백질 하한 (g)
+        - max_sodium: 나트륨 상한 (mg)
+        - max_spicy_level / min_spicy_level: 매운맛 범위 0~5
+        - min_price / max_price: 가격 범위 (원)
+        - temperature_type: HOT | COLD (BOTH 또는 미전달 시 조건 없음)
+        - vegetarian_type: VEGAN | VEGETARIAN | NONE
+        - season: SPRING | SUMMER | FALL | WINTER | ALL
+        - category_id: 카테고리 ID (모르면 tool_get_categories 먼저 호출)
+        - exclude_allergies: 제외할 알레르기 콤마 구분 영문 enum
+          (MILK, EGG, WHEAT, SOY, PEANUT, WALNUT, PINE, SHRIMP, CRAB, SQUID, CLAM, BEEF, PORK, CHICKEN, PEACH, TOMATO, BUCKWHEAT)
+        - limit: 반환할 최대 메뉴 수 (추천은 보통 3~5 권장)
+
+        사용 기준:
+        - 영양소/가격/알레르기/온도/채식/계절 등 속성 조건으로 메뉴를 찾을 때 우선 사용
+        - "단백질 많은 거", "저칼로리", "비건", "5천원 이하", "알레르기 있어", "안 매운 거" 등 단일·복합 조건 모두 처리
+        - 판매량 기준("잘 팔리는")이 포함된 경우 tool_get_top_menus 를 먼저 호출한 뒤 tool_get_menu_detail_recommend 로 영양소를 비교할 것
+        """
+        req = {k: v for k, v in {
+            "max_calorie": max_calorie, "min_calorie": min_calorie,
+            "min_protein": min_protein, "max_sodium": max_sodium,
+            "max_spicy_level": max_spicy_level, "min_spicy_level": min_spicy_level,
+            "min_price": min_price, "max_price": max_price,
+            "temperature_type": temperature_type, "vegetarian_type": vegetarian_type,
+            "season": season, "category_id": category_id,
+            "exclude_allergies": exclude_allergies, "limit": limit,
+        }.items() if v is not None}
+        result = json.dumps(
+            [m.model_dump() for m in await filter_menus(spring, **req)],
+            ensure_ascii=False,
+        )
+        return await _log_tool("filter_menus", req, result)
+
     return [
+        tool_get_categories,
         tool_get_all_menus,
         tool_get_top_menus,
         tool_get_menus_by_category,
         tool_get_menu_detail_recommend,
+        tool_filter_menus,
     ]

--- a/mcp/tools/menu_tools.py
+++ b/mcp/tools/menu_tools.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from adapter.spring_adapter import SpringAdapter
 from core.exceptions import SpringApiError
-from domain.menu import Category, MenuDetail, MenuSummary, TopMenuSummary
+from domain.menu import Category, FilterMenuResult, MenuDetail, MenuSummary, TopMenuSummary
 
 
 async def get_categories(spring: SpringAdapter) -> list[Category]:
@@ -36,6 +36,61 @@ async def get_top_menus(spring: SpringAdapter, limit: int = 5) -> list[TopMenuSu
         return [TopMenuSummary.model_validate(item) for item in data]
     except ValidationError as exc:
         raise SpringApiError("인기 메뉴 응답 스키마 불일치", status_code=502) from exc
+
+
+async def filter_menus(
+    spring: SpringAdapter,
+    max_calorie: Optional[int] = None,
+    min_calorie: Optional[int] = None,
+    min_protein: Optional[float] = None,
+    max_sodium: Optional[float] = None,
+    max_spicy_level: Optional[int] = None,
+    min_spicy_level: Optional[int] = None,
+    min_price: Optional[int] = None,
+    max_price: Optional[int] = None,
+    temperature_type: Optional[str] = None,
+    vegetarian_type: Optional[str] = None,
+    season: Optional[str] = None,
+    category_id: Optional[int] = None,
+    exclude_allergies: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> list[FilterMenuResult]:
+    """메뉴 필터 조회 — GET /api/menus/filter"""
+    params: dict = {}
+    if max_calorie is not None:
+        params["maxCalorie"] = max_calorie
+    if min_calorie is not None:
+        params["minCalorie"] = min_calorie
+    if min_protein is not None:
+        params["minProtein"] = min_protein
+    if max_sodium is not None:
+        params["maxSodium"] = max_sodium
+    if max_spicy_level is not None:
+        params["maxSpicyLevel"] = max_spicy_level
+    if min_spicy_level is not None:
+        params["minSpicyLevel"] = min_spicy_level
+    if min_price is not None:
+        params["minPrice"] = min_price
+    if max_price is not None:
+        params["maxPrice"] = max_price
+    if temperature_type is not None:
+        params["temperatureType"] = temperature_type
+    if vegetarian_type is not None:
+        params["vegetarianType"] = vegetarian_type
+    if season is not None:
+        params["season"] = season
+    if category_id is not None:
+        params["categoryId"] = category_id
+    if exclude_allergies is not None:
+        params["excludeAllergies"] = exclude_allergies
+    if limit is not None:
+        params["limit"] = limit
+
+    data = await spring.get("/api/menus/filter", params=params if params else None)
+    try:
+        return [FilterMenuResult.model_validate(item) for item in data]
+    except ValidationError as exc:
+        raise SpringApiError("필터 메뉴 응답 스키마 불일치", status_code=502) from exc
 
 
 async def get_menu_detail(spring: SpringAdapter, menu_id: int) -> MenuDetail:

--- a/service/graph/nodes/intent_node.py
+++ b/service/graph/nodes/intent_node.py
@@ -7,7 +7,7 @@
 import logging
 
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import ChatOpenAI
 
 from core.config import get_settings
 from service.graph.state import KioskState
@@ -23,12 +23,12 @@ _INTENT_SYSTEM_PROMPT = """
 """.strip()
 
 
-def _build_llm() -> ChatGoogleGenerativeAI:
+def _build_llm() -> ChatOpenAI:
     s = get_settings()
-    return ChatGoogleGenerativeAI(
-        model=s.gemini_model,
-        google_api_key=s.gemini_api_key,
-        temperature=0,  # 의도 분류는 일관성이 중요하므로 0
+    return ChatOpenAI(
+        model=s.openai_model,
+        api_key=s.openai_api_key,
+        temperature=0,
     )
 
 

--- a/service/graph/nodes/order_node.py
+++ b/service/graph/nodes/order_node.py
@@ -4,7 +4,7 @@
 make_order_tools()로 생성된 Tool 목록을 LangGraph create_react_agent에 주입한다.
 """
 
-from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from adapter.spring_adapter import SpringAdapter
@@ -27,9 +27,9 @@ _ORDER_SYSTEM_PROMPT = """
 async def run_order_agent(state: KioskState, spring: SpringAdapter) -> dict:
     """주문/장바구니 ReAct 에이전트를 실행하고 결과를 반환한다."""
     s = get_settings()
-    llm = ChatGoogleGenerativeAI(
-        model=s.gemini_model,
-        google_api_key=s.gemini_api_key,
+    llm = ChatOpenAI(
+        model=s.openai_model,
+        api_key=s.openai_api_key,
         temperature=0.3,
     )
 

--- a/service/graph/nodes/payment_node.py
+++ b/service/graph/nodes/payment_node.py
@@ -4,7 +4,7 @@
 흐름을 순서대로 처리하는 ReAct 에이전트.
 """
 
-from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from adapter.spring_adapter import SpringAdapter
@@ -35,10 +35,10 @@ _PAYMENT_SYSTEM_PROMPT = """
 async def run_payment_agent(state: KioskState, spring: SpringAdapter) -> dict:
     """결제 흐름 ReAct 에이전트를 실행하고 결과를 반환한다."""
     s = get_settings()
-    llm = ChatGoogleGenerativeAI(
-        model=s.gemini_model,
-        google_api_key=s.gemini_api_key,
-        temperature=0,  # 결제는 일관성이 중요하므로 0
+    llm = ChatOpenAI(
+        model=s.openai_model,
+        api_key=s.openai_api_key,
+        temperature=0,
     )
 
     tools = make_payment_tools(spring, state["session_id"])

--- a/service/graph/nodes/recommend_node.py
+++ b/service/graph/nodes/recommend_node.py
@@ -23,16 +23,36 @@ _RECOMMEND_SYSTEM_PROMPT = """
 - 추천 후 "장바구니에 담아드릴까요?" 로 자연스럽게 주문으로 유도해라.
 - 응답은 한국어로 친절하고 간결하게 해라.
 
-사용자 발화 → 필드 활용 기준:
-- "칼로리 낮은 거" → calorie 낮은 메뉴 우선
-- "매운 거" → spicyLevel 3 이상, "안 매운 거" → spicyLevel 0
-- "알레르기 있어" (예: 땅콩) → allergies에 해당 항목 없는 메뉴만 추천
-- "채식이야 / 비건이야" → vegetarianType = VEGETARIAN / VEGAN 메뉴만
-- "따뜻한 거" → temperatureType = HOT, "시원한 거" → COLD
-- "여름/봄/가을/겨울 메뉴" → seasonRecommended 해당 계절 또는 ALL
-- "단백질 많은 거" → protein 높은 메뉴 우선
-- "나트륨 낮은 거" → sodium 낮은 메뉴 우선
+Tool 선택 기준:
+- 영양소·알레르기·온도·채식·계절 조건 → tool_filter_menus 우선 사용
+- "잘 팔리는", "인기 메뉴" → tool_get_top_menus 사용
+- "밥류", "음료" 등 카테고리 이름이 포함된 요청 → tool_get_categories 로 categoryId 확인 후 tool_get_menus_by_category 사용
+- 조건 없이 전체 메뉴 → tool_get_all_menus 사용
+
+사용자 발화 → tool_filter_menus 파라미터 매핑:
+- "칼로리 낮은 거" → max_calorie 적정값 설정
+- "고칼로리" → min_calorie 적정값 설정
+- "저렴한 거", "N원 이하" → max_price 설정, "N원 이상" → min_price 설정
+- "단백질 많은 거" → min_protein 적정값 설정
+- "나트륨 낮은 거" → max_sodium 적정값 설정
+- "매운 거" → min_spicy_level=3, "안 매운 거" → max_spicy_level=1
+- "알레르기 있어" (예: 땅콩) → exclude_allergies="PEANUT"
+  알레르기 영문 enum: MILK, EGG, WHEAT, SOY, PEANUT, WALNUT, PINE, SHRIMP, CRAB, SQUID, CLAM, BEEF, PORK, CHICKEN, PEACH, TOMATO, BUCKWHEAT
+- "채식이야" → vegetarian_type="VEGETARIAN", "비건이야" → vegetarian_type="VEGAN"
+- "따뜻한 거" → temperature_type="HOT", "시원한 거" → temperature_type="COLD"
+- "여름/봄/가을/겨울 메뉴" → season="SUMMER"/"SPRING"/"FALL"/"WINTER"
 - 품절(isSoldOut=true) 메뉴는 절대 추천하지 마라.
+
+체인(복합) 쿼리 처리 패턴:
+- 속성 조건만 있을 때: tool_filter_menus 한 번으로 해결
+  예) "저칼로리 비건 메뉴" → tool_filter_menus(max_calorie=500, vegetarian_type="VEGAN")
+- 판매량 + 속성 조건이 함께 있을 때: 반드시 두 단계로 처리
+  예) "오늘 잘 팔리는 3개 중 단백질 가장 높은 것"
+    1. tool_get_top_menus(limit=3) → menuId 목록 획득
+    2. tool_get_menu_detail_recommend(menuId) 를 각각 호출 → nutrition 확인
+    3. protein 값 비교 후 최고값 추천
+  예) "인기 5개 중 나트륨 낮은 것" → 위와 동일 패턴, sodium 비교
+- filter 결과가 너무 많으면 그 중 가장 잘 맞는 1~3개를 골라 추천해라.
 """.strip()
 
 

--- a/service/graph/nodes/recommend_node.py
+++ b/service/graph/nodes/recommend_node.py
@@ -4,7 +4,7 @@
 눈치 감지 노드(nunchi_node)에서도 이 노드로 연결된다.
 """
 
-from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from adapter.spring_adapter import SpringAdapter
@@ -59,10 +59,10 @@ Tool 선택 기준:
 async def run_recommend_agent(state: KioskState, spring: SpringAdapter) -> dict:
     """추천 ReAct 에이전트를 실행하고 결과를 반환한다."""
     s = get_settings()
-    llm = ChatGoogleGenerativeAI(
-        model=s.gemini_model,
-        google_api_key=s.gemini_api_key,
-        temperature=0.5,  # 추천은 약간의 다양성 허용
+    llm = ChatOpenAI(
+        model=s.openai_model,
+        api_key=s.openai_api_key,
+        temperature=0.5,
     )
 
     tools = make_recommend_tools(spring, state["session_id"])


### PR DESCRIPTION

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #8 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
 - `GET /api/menus/filter` Spring API 연동 — 칼로리/단백질/나트륨/가격/알레르기/온도/채식/계절/limit 전 파라미터 지원
  - `tool_filter_menus` Tool 등록 — 복합 조건 추천 요청을 한 번의 API 호출로 처리                                                                           
  - `tool_get_categories` Tool 추가 — 카테고리 이름 기반 요청 시 categoryId 조회용                                                                          
  - 추천 시스템 프롬프트 개선 — Tool 선택 기준 및 체인 쿼리 패턴 명시

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 판매량 + 영양소 복합 조건 ("잘 팔리는 3개 중 단백질 최고")은 `get_top_menus` → `get_menu_detail` × N 체인으로 처리됩니다. filter API 단일 호출로는 판매량 기준을 포함할 수 없어 두 단계로 분리했습니다.
 - `tool_filter_menus` 의 `limit` 파라미터는 추천 시 3~5 권장으로 프롬프트에 명시했습니다. LLM이 조건이 넓은 요청에서도 과도한 결과를 받지 않도록 유도합니다. 

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
