### PR TITLE
[Chore] CD 파이프라인에 EC2 자동 배포 step 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,3 +32,16 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /home/ubuntu/nunchi
+            aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+              docker login --username AWS --password-stdin ${{ steps.login-ecr.outputs.registry }}
+            docker compose pull fastapi mcp
+            docker compose up -d --no-deps fastapi mcp


### PR DESCRIPTION
ECR push 완료 후 EC2에 SSH 접속해 fastapi/mcp 서비스를 자동으로 pull 및 재시작

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #13 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 파이프라인이 Docker 이미지 배포 프로세스를 자동화하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->