### PR TITLE
[Chore] MCP 서버 전용 설정 클래스 분리 (McpSettings)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,13 @@
       "Bash(gh pr:*)",
       "Bash(git commit *)",
       "Bash(gh api *)",
-      "Bash(python *)"
+      "Bash(python *)",
+      "Bash(curl *)",
+      "Bash(git stash *)",
+      "Bash(git switch *)",
+      "Bash(git pull *)",
+      "Bash(git rm *)",
+      "Bash(git *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,19 +4,24 @@
       "Bash(pip3 install:*)",
       "Bash(python3:*)",
       "Bash(git add:*)",
+      "Bash(git add *)",
       "Bash(git commit -m ':*)",
-      "WebFetch(domain:github.com)",
-      "Bash(git push:*)",
-      "Bash(gh pr:*)",
       "Bash(git commit *)",
-      "Bash(gh api *)",
-      "Bash(python *)",
-      "Bash(curl *)",
+      "Bash(git push *)",
+      "Bash(git push:*)",
       "Bash(git stash *)",
       "Bash(git switch *)",
       "Bash(git pull *)",
-      "Bash(git rm *)",
-      "Bash(git *)"
+      "Bash(git log *)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git fetch *)",
+      "Bash(git branch *)",
+      "Bash(gh pr:*)",
+      "Bash(gh pr *)",
+      "Bash(gh api *)",
+      "Bash(/opt/homebrew/bin/gh *)",
+      "WebFetch(domain:github.com)"
     ]
   }
 }

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,255 +1,81 @@
-# FastMCP 서버 전환 계획
+# MCP 서버 설정 분리 계획
 
-**목표**: 현재 `@tool` 방식(FastAPI 내부에서만 동작)을 FastMCP 독립 프로세스로 전환해
-Claude Desktop 등 외부 AI 클라이언트에서도 Tool 직접 호출 가능하게 만든다.
+## 왜 고쳐야 하나
 
----
-
-## 변경 요약
-
-| 구분 | 현재 | 변경 후 |
-|------|------|---------|
-| Tool 방식 | LangChain `@tool` 데코레이터 | FastMCP `@mcp_app.tool()` |
-| 실행 위치 | FastAPI 프로세스 내부 | 포트 8090 독립 프로세스 |
-| session_id 주입 | 클로저(팩토리 함수)로 주입 | Tool 파라미터로 직접 전달 |
-| nodes 연결 방식 | `make_order_tools(spring, session_id)` | `MultiServerMCPClient` SSE 연결 |
-| Spring 어댑터 위치 | 각 노드에서 주입 | MCP 서버 내부에서 전역 생성 |
-
----
-
-## 변경 파일 목록
-
-### 신규 생성
-1. `mcp/mcp_server.py` — FastMCP 서버 본체 (port 8090)
-2. `.env.local` — 로컬 개발용 환경 변수 템플릿
-3. `docker-compose.yml` — fastapi + mcp 동시 실행 구성
-
-### 수정
-4. `requirements.txt` — `mcp[cli]`, `langchain-mcp-adapters` 의존성 추가
-5. `core/config.py` — `mcp_server_url` 설정 추가
-6. `service/graph/nodes/order_node.py` — `make_order_tools` → `MultiServerMCPClient` 교체
-7. `service/graph/nodes/recommend_node.py` — `make_recommend_tools` → `MultiServerMCPClient` 교체
-8. `service/graph/nodes/payment_node.py` — `make_payment_tools` → `MultiServerMCPClient` 교체
-
-### 유지 (변경 없음)
-- `mcp/tools/*.py` — 비즈니스 로직 그대로 재사용
-- `mcp/server.py` — 전환 완료 후 삭제 예정, 지금은 유지
-
----
-
-## 1단계: 의존성 및 설정 추가
-
-### `requirements.txt` 추가
-```
-mcp[cli]>=1.0.0
-langchain-mcp-adapters>=0.1.0
-```
-
-### `core/config.py` 수정
-`Settings` 클래스에 아래 필드 추가:
-```python
-mcp_server_url: str = "http://localhost:8090"
-```
-
----
-
-## 2단계: `mcp/mcp_server.py` 신규 생성
-
-FastMCP 인스턴스 하나에 전체 Tool을 등록한다.
-`mcp/tools/*.py`의 함수를 그대로 호출하고, `spring: SpringAdapter`는 서버 시작 시 전역으로 생성한다.
-`session_id`는 Tool 파라미터로 직접 받는다.
+지금 MCP 서버(`kiosk_mcp/mcp_server.py`)는 FastAPI 서버와 **같은 `Settings` 클래스**를 공유한다.
 
 ```python
-from contextlib import asynccontextmanager
-from mcp.server.fastmcp import FastMCP
-from adapter.spring_adapter import SpringAdapter
+# core/config.py
+class Settings(BaseSettings):
+    spring_base_url: str = ...
+    openai_api_key: str = Field(min_length=1, alias="OPEN_API_KEY")  # 필수
+    openai_model: str = ...
+    mcp_server_url: str = ...
+```
+
+MCP 서버는 Spring API만 호출하고 OpenAI를 전혀 쓰지 않는데,
+`Settings`에 `openai_api_key`가 필수 필드로 박혀 있어서
+**OpenAI 키 없이는 MCP 서버 자체가 기동 불가**한 상태다.
+
+그래서 Claude Desktop config에 억지로 OpenAI 키를 넣고 있다.
+→ 불필요한 민감정보 노출, 논리적으로도 맞지 않음.
+
+---
+
+## 고칠 내용
+
+### 1. `core/config.py` — McpSettings 클래스 추가
+
+```python
+class McpSettings(BaseSettings):
+    spring_base_url: str = "http://localhost:8080"
+    spring_timeout: int = Field(default=5, ge=1)
+
+    model_config = SettingsConfigDict(
+        env_file=(".env", ".env.local"),
+        env_file_encoding="utf-8",
+        populate_by_name=True,
+        extra="ignore",
+    )
+
+@lru_cache
+def get_mcp_settings() -> McpSettings:
+    return McpSettings()
+```
+
+### 2. `kiosk_mcp/mcp_server.py` — get_settings → get_mcp_settings로 교체
+
+```python
+# 변경 전
 from core.config import get_settings
-from mcp.tools.cart_tools import add_cart_item, get_cart, remove_cart_item, update_cart_item
-from mcp.tools.menu_tools import filter_menus, get_categories, get_menu_detail, get_menus, get_top_menus
-from mcp.tools.order_tools import confirm_order
-from mcp.tools.payment_tools import request_payment
-from mcp.tools.session_tools import complete_session, save_tool_log
+_settings = get_settings()
 
-mcp_app = FastMCP("nunchi-kiosk")
-_spring: SpringAdapter | None = None
-
-# --- 메뉴/카테고리 Tool ---
-
-@mcp_app.tool()
-async def tool_get_categories() -> str:
-    """카테고리 목록을 조회한다."""
-    ...
-
-@mcp_app.tool()
-async def tool_get_menus(category_id: int | None = None) -> str:
-    """메뉴 목록 조회. category_id 지정 시 해당 카테고리만 반환."""
-    ...
-
-@mcp_app.tool()
-async def tool_get_top_menus(limit: int = 5) -> str:
-    """오늘 판매량 기준 인기 메뉴 목록."""
-    ...
-
-@mcp_app.tool()
-async def tool_get_menu_detail(menu_id: int) -> str:
-    """메뉴 상세 + 옵션. 장바구니 담기 전 반드시 호출."""
-    ...
-
-@mcp_app.tool()
-async def tool_filter_menus(...) -> str:
-    """조건(칼로리/알레르기/채식/온도/계절/가격) 기반 메뉴 필터링."""
-    ...
-
-# --- 장바구니 Tool ---
-
-@mcp_app.tool()
-async def tool_add_cart_item(session_id: int, menu_id: int, quantity: int, option_ids: list[int]) -> str:
-    """장바구니에 메뉴 담기."""
-    ...
-
-@mcp_app.tool()
-async def tool_get_cart(session_id: int) -> str:
-    """현재 장바구니 전체 조회."""
-    ...
-
-@mcp_app.tool()
-async def tool_update_cart_item(session_id: int, item_id: str, quantity: int) -> str:
-    """장바구니 수량 수정."""
-    ...
-
-@mcp_app.tool()
-async def tool_remove_cart_item(session_id: int, item_id: str) -> str:
-    """장바구니 아이템 삭제."""
-    ...
-
-# --- 주문/결제 Tool ---
-
-@mcp_app.tool()
-async def tool_confirm_order(session_id: int) -> str:
-    """장바구니를 주문으로 확정. 결제 전 반드시 호출."""
-    ...
-
-@mcp_app.tool()
-async def tool_request_payment(session_id: int, order_id: int, method: str) -> str:
-    """결제 요청. method: IC_CARD | VEIN_AUTH"""
-    ...
-
-@mcp_app.tool()
-async def tool_complete_session(session_id: int) -> str:
-    """주문 세션 종료. 결제 완료 후 호출."""
-    ...
+# 변경 후
+from core.config import get_mcp_settings
+_settings = get_mcp_settings()
 ```
 
-**진입점 (`__main__`)**:
-```python
-if __name__ == "__main__":
-    import asyncio
-    s = get_settings()
-    _spring = SpringAdapter(s.spring_base_url)
-    mcp_app.run(transport="sse", port=8090)
+### 3. Claude Desktop config — OPEN_API_KEY 줄 제거
+
+```json
+"nunchi-kiosk": {
+  "command": "/Users/hyodongg/Desktop/workspace/capstone_ai/venv/bin/python",
+  "args": ["-m", "kiosk_mcp.mcp_server"],
+  "cwd": "/Users/hyodongg/Desktop/workspace/capstone_ai",
+  "env": {
+    "MCP_TRANSPORT": "stdio",
+    "PYTHONPATH": "/Users/hyodongg/Desktop/workspace/capstone_ai",
+    "SPRING_BASE_URL": "http://localhost:8080"
+  }
+}
 ```
 
 ---
 
-## 3단계: nodes 수정 — `MultiServerMCPClient` 교체
+## 변경 범위 요약
 
-세 노드 모두 동일한 패턴으로 변경.
-`spring: SpringAdapter` 파라미터 제거, session_id를 시스템 프롬프트에 포함시켜 LLM이 Tool 호출 시 자동으로 넘기게 한다.
-
-### `order_node.py` 변경 패턴
-```python
-from langchain_mcp_adapters.client import MultiServerMCPClient
-from core.config import get_settings
-
-async def run_order_agent(state: KioskState) -> dict:
-    s = get_settings()
-    session_id = state["session_id"]
-    prompt = _ORDER_SYSTEM_PROMPT + f"\n\n현재 세션 ID: {session_id} — 장바구니/주문 Tool 호출 시 반드시 session_id={session_id} 를 전달해라."
-
-    async with MultiServerMCPClient({"kiosk": {"url": s.mcp_server_url + "/sse", "transport": "sse"}}) as client:
-        tools = client.get_tools()
-        llm = ChatOpenAI(model=s.openai_model, api_key=s.openai_api_key, temperature=0.3)
-        agent = create_react_agent(llm, tools, prompt=prompt)
-        result = await agent.ainvoke({"messages": state["messages"]})
-
-    return {"messages": result["messages"]}
-```
-
-- `recommend_node.py` — 동일 패턴, `make_recommend_tools` 제거
-- `payment_node.py` — 동일 패턴, `make_payment_tools` 제거
-
----
-
-## 4단계: `.env.local` 신규 생성
-
-로컬 개발 시 사용할 환경변수 템플릿 (`.gitignore`에 포함):
-```
-OPEN_API_KEY=sk-...
-SPRING_BASE_URL=http://localhost:8080
-MCP_SERVER_URL=http://localhost:8090
-```
-
----
-
-## 5단계: `docker-compose.yml` 신규 생성
-
-같은 AI 이미지를 두 컨테이너로 분리 실행 (FastAPI / MCP 서버).
-
-```yaml
-version: "3.9"
-services:
-  fastapi:
-    build: .
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
-    ports:
-      - "8000:8000"
-    env_file: .env
-
-  mcp:
-    build: .
-    command: python -m mcp.mcp_server
-    ports:
-      - "8090:8090"
-    env_file: .env
-```
-
----
-
-## 작업 순서
-
-| 순서 | 파일 | 작업 내용 |
-|------|------|----------|
-| 1 | `requirements.txt` | `mcp[cli]`, `langchain-mcp-adapters` 추가 |
-| 2 | `core/config.py` | `mcp_server_url` 필드 추가 |
-| 3 | `mcp/mcp_server.py` | FastMCP 서버 전체 구현 |
-| 4 | `service/graph/nodes/order_node.py` | `MultiServerMCPClient` 교체, spring 파라미터 제거 |
-| 5 | `service/graph/nodes/recommend_node.py` | 동일 |
-| 6 | `service/graph/nodes/payment_node.py` | 동일 |
-| 7 | `.env.local` | 로컬 환경변수 템플릿 생성 |
-| 8 | `docker-compose.yml` | 서비스 구성 파일 생성 |
-| 9 | `mcp/server.py` | 레거시 파일 삭제 |
-
----
-
-## 로컬 실행 방법 (도커 없이)
-
-터미널 3개를 동시에 실행:
-```
-# 터미널 1 — Spring
-cd spring_project && ./gradlew bootRun
-
-# 터미널 2 — MCP 서버
-cd capstone_ai && python -m mcp.mcp_server
-
-# 터미널 3 — FastAPI
-cd capstone_ai && uvicorn app.main:app --reload
-```
-
----
-
-## 변경하지 않는 것
-
-- `mcp/tools/*.py` — 비즈니스 로직 그대로 재사용, 함수 시그니처 유지
-- Spring 코드 — 수정 없음 (MCP 서버도 동일한 Spring HTTP API 호출)
-- 도메인 모델 (`domain/*.py`) — 변경 없음
-- `adapter/spring_adapter.py` — 변경 없음
+| 파일 | 변경 내용 |
+|------|-----------|
+| `core/config.py` | `McpSettings` 클래스 추가, `get_mcp_settings()` 함수 추가 |
+| `kiosk_mcp/mcp_server.py` | `get_settings()` → `get_mcp_settings()` 교체 |
+| `claude_desktop_config.json` | `OPEN_API_KEY` 항목 제거 |

--- a/PLAN.md
+++ b/PLAN.md
@@ -59,12 +59,12 @@ _settings = get_mcp_settings()
 
 ```json
 "nunchi-kiosk": {
-  "command": "/Users/hyodongg/Desktop/workspace/capstone_ai/venv/bin/python",
+  "command": "/path/to/project/venv/bin/python",
   "args": ["-m", "kiosk_mcp.mcp_server"],
-  "cwd": "/Users/hyodongg/Desktop/workspace/capstone_ai",
+  "cwd": "/path/to/project",
   "env": {
     "MCP_TRANSPORT": "stdio",
-    "PYTHONPATH": "/Users/hyodongg/Desktop/workspace/capstone_ai",
+    "PYTHONPATH": "/path/to/project",
     "SPRING_BASE_URL": "http://localhost:8080"
   }
 }

--- a/RESULT.md
+++ b/RESULT.md
@@ -1,183 +1,259 @@
-# 초기 세팅 진행 보고
+# MCP 개발 포트폴리오 — NUNCHI KIOSK AI 서버
+
+**프로젝트**: 눈치(NUNCHI) 키오스크 — LLM Agentic AI 기반 자율주문 키오스크  
+**역할**: FastAPI AI 서버 설계 및 MCP 서버 구축  
+**기간**: 캡스톤 프로젝트 (2026)
 
 ---
 
-## ✅ Step 1 완료 — core/ (공통 기반)
+## 1. MCP란 무엇인가
 
-```text
-core/
-├── __init__.py
-├── config.py       ← 환경변수 관리 (SPRING_BASE_URL, OPENAI_API_KEY 등)
-└── exceptions.py   ← 공통 예외 정의 (KioskError, SpringApiError 등)
+**MCP(Model Context Protocol)**는 Anthropic이 정의한 개방형 표준 프로토콜로,  
+AI 모델(LLM)과 외부 시스템 사이의 Tool 호출 방식을 표준화한다.
+
+### 기존 방식의 한계
+
+```
+LLM ──(독자 규격)──> 외부 시스템 A
+LLM ──(또 다른 규격)──> 외부 시스템 B
 ```
 
-`core/`는 프로젝트 전역 공통 기반. 어느 계층에서도 참조하되, 다른 계층에는 의존하지 않는다.
+플랫폼마다 Tool 정의 방식, 호출 포맷, 인증 방식이 달라 재사용이 불가능했다.
 
-- `config.py`: `.env`를 읽어 설정값 관리. Spring의 `@ConfigurationProperties`와 같은 역할
-- `exceptions.py`: `KioskError` 베이스에서 `SpringApiError`, `OrderNotConfirmedError` 등 계층별 예외 분기
+### MCP가 해결하는 것
 
----
-
-## ✅ Step 2 완료 — domain/ (데이터 모델)
-
-```text
-domain/
-├── __init__.py
-├── session.py      ← SessionMode, SessionStatus, SessionResult
-├── menu.py         ← Category, MenuSummary, MenuDetail, OptionGroup, Option
-├── cart.py         ← CartItem(item_id 포함), CartResponse
-├── order.py        ← OrderStatus, OrderResult
-└── payment.py      ← PaymentMethod, PaymentStatus, PaymentResult
+```
+Claude Desktop ─┐
+LangGraph Agent ─┤──(MCP 표준)──> MCP Server ──> 실제 시스템 (DB, API 등)
+기타 AI 클라이언트 ─┘
 ```
 
-Spring 응답 구조를 Python 타입으로 정의한 Pydantic 모델.
-Java의 `record` + `@Valid`처럼 타입 선언만 하면 자동 검증/변환된다.
+MCP 서버 하나를 만들면, 이를 지원하는 **모든 AI 클라이언트**에서 동일한 Tool을 호출할 수 있다.
 
----
+### MCP의 핵심 개념
 
-## ✅ Step 3 완료 — adapter/ (외부 연동 계층)
+| 개념 | 설명 |
+|------|------|
+| **Tool** | AI가 호출할 수 있는 함수. 이름, 파라미터, 반환값으로 구성 |
+| **MCP Server** | Tool을 외부에 노출하는 독립 프로세스 |
+| **MCP Client** | Tool을 호출하는 쪽 (Claude Desktop, LangGraph 등) |
+| **Transport** | 서버-클라이언트 간 통신 방식. `stdio`(로컬) 또는 `SSE`(네트워크) |
 
-```text
-adapter/
-├── __init__.py
-├── ports.py            ← SpringPort 추상 인터페이스 (Java interface와 같은 역할)
-├── spring_adapter.py   ← HTTPX 기반 Spring HTTP 연동 구현체
-├── openai_adapter.py   ← OpenAI 연동 골격 (transcribe, chat, speak)
-└── factory.py          ← 싱글턴 Adapter 인스턴스 생성 함수
+### stdio vs SSE 트랜스포트
+
+```
+stdio: Claude Desktop ──stdin/stdout──> MCP Server (로컬 프로세스로 실행)
+SSE:   LangGraph Agent ──HTTP SSE──────> MCP Server (포트 8090 리슨)
 ```
 
-Spring의 `WebClient`와 같은 역할. 외부 API 변경이 생겨도 adapter 안에서만 수정한다.
-
-- `spring_adapter.py`: Spring 공통 응답 `{ code, msg, data }` 파싱 + 예외 변환이 핵심
-- `factory.py`: `get_spring_adapter()`로 FastAPI `Depends`에 주입해서 사용
+이 프로젝트는 두 트랜스포트를 환경변수 하나(`MCP_TRANSPORT`)로 전환 가능하게 설계했다.
 
 ---
 
-## ✅ Step 4 완료 — mcp/ (MCP Tool 골격)
+## 2. 프로젝트 전체 아키텍처
 
-```text
-mcp/
-├── __init__.py
-├── server.py               ← MCP 서버 등록 진입점 (골격)
-└── tools/
-    ├── __init__.py
-    ├── session_tools.py    ← create_session, complete_session
-    ├── menu_tools.py       ← get_categories, get_menus, get_menu_detail
-    ├── cart_tools.py       ← add_cart_item, get_cart, update_cart_item, remove_cart_item
-    ├── order_tools.py      ← confirm_order
-    └── payment_tools.py    ← request_payment
+```
+[사용자]
+   │ 음성 / 터치
+   ▼
+[React 키오스크 UI]
+   │ REST / WebSocket
+   ▼
+[FastAPI AI 서버]  ◄──── LangGraph (의도 분류 → 에이전트 분기 → Tool 실행)
+   │ MultiServerMCPClient (SSE)
+   ▼
+[FastMCP 서버 — kiosk_mcp]  ◄──── Claude Desktop (stdio)
+   │ HTTP REST
+   ▼
+[Spring Boot 백엔드]
+   │
+   ▼
+[PostgreSQL]
 ```
 
-`mcp/`는 LLM(AI)이 호출하는 함수들을 정의하는 곳.
-Spring의 `@RestController`가 HTTP 요청을 받는 것처럼, MCP Tool은 LLM의 function call 요청을 받는 입구다.
-
-각 Tool은 얇게 유지하고 실제 HTTP 호출은 `SpringAdapter`에 위임한다.
+**FastMCP 서버는 두 방향에서 동시에 접근 가능하다:**
+- 키오스크 내부: LangGraph 에이전트가 SSE로 연결
+- 외부: Claude Desktop이 stdio로 직접 연결
 
 ---
 
-## ✅ Step 5, 6 완료 — service/, app/ (비즈니스 로직 + FastAPI 진입점)
+## 3. 무엇을 만들었나
 
-```text
-service/
-├── __init__.py
-├── agent_service.py    ← LLM + Tool 체이닝 실행 (골격)
-└── voice_pipeline.py   ← STT → Agent → TTS 파이프라인 (골격)
+### 3-1. FastMCP 독립 서버 (`kiosk_mcp/mcp_server.py`)
 
-app/
-├── __init__.py
-├── main.py             ← FastAPI 앱, /health, 예외 핸들러, 라우터 등록
-└── api/
-    ├── __init__.py
-    └── voice.py        ← 음성 처리 API 라우터 (골격)
+LangChain `@tool` 방식(FastAPI 프로세스 내부에서만 동작)을 **FastMCP 독립 서버**로 전환했다.
+
+**이전 구조의 문제:**
+```python
+# FastAPI 안에서만 쓸 수 있는 @tool
+@tool
+def get_menus(category_id: int) -> str:
+    ...
+# → 외부 Claude Desktop 접근 불가, 클로저로 spring 주입 필요
 ```
 
-### service/ 의 역할
+**전환 후:**
+```python
+# FastMCP 서버로 외부 공개
+mcp_app = FastMCP("nunchi-kiosk")
 
-`service/`는 **비즈니스 로직이 들어가는 계층**이다.
-Spring의 `@Service`와 같은 역할.
-
-- `agent_service.py`: LLM에 메시지와 Tool 스키마를 전달하고, Tool 호출 루프를 관리
-- `voice_pipeline.py`: STT → AgentService → TTS 흐름을 조합하는 파이프라인
-
-### app/ 의 역할
-
-`app/`은 **HTTP 요청을 받는 가장 바깥쪽 계층**이다.
-Spring의 `@RestController` + `main()` 진입점과 같은 역할.
-
-- `main.py`: FastAPI 앱 생성, 라우터 등록, 공통 예외 핸들러 등록
-- `api/voice.py`: 음성 API 라우터. 입력 파싱과 응답 반환만 담당하고 로직은 Service에 위임
-
----
-
-## 완성된 전체 폴더 구조
-
-```text
-capstone_ai/
-├── app/
-│   ├── __init__.py
-│   ├── main.py             ← FastAPI 앱 진입점, /health
-│   └── api/
-│       ├── __init__.py
-│       └── voice.py
-├── service/
-│   ├── __init__.py
-│   ├── agent_service.py
-│   └── voice_pipeline.py
-├── adapter/
-│   ├── __init__.py
-│   ├── ports.py
-│   ├── factory.py
-│   ├── openai_adapter.py
-│   └── spring_adapter.py
-├── mcp/
-│   ├── __init__.py
-│   ├── server.py
-│   └── tools/
-│       ├── __init__.py
-│       ├── session_tools.py
-│       ├── menu_tools.py
-│       ├── cart_tools.py
-│       ├── order_tools.py
-│       └── payment_tools.py
-├── domain/
-│   ├── __init__.py
-│   ├── session.py
-│   ├── menu.py
-│   ├── cart.py
-│   ├── order.py
-│   └── payment.py
-├── core/
-│   ├── __init__.py
-│   ├── config.py
-│   └── exceptions.py
-├── .env.example
-└── requirements.txt
+@mcp_app.tool()
+async def tool_get_menus(category_id: Optional[int] = None) -> str:
+    """메뉴 목록을 조회한다."""
+    ...
 ```
 
----
+### 3-2. 구현한 MCP Tool 목록 (총 14개)
 
-## 서버 실행 방법
+| 분류 | Tool | 기능 |
+|------|------|------|
+| **세션** | `tool_create_session` | 주문 세션 생성, session_id 발급 |
+| **세션** | `tool_save_message` | 대화 메시지 DB 저장 (USER/ASSISTANT) |
+| **메뉴** | `tool_get_categories` | 카테고리 목록 조회 |
+| **메뉴** | `tool_get_menus` | 전체 / 카테고리별 메뉴 조회 |
+| **메뉴** | `tool_get_top_menus` | 오늘 판매량 기준 인기 메뉴 |
+| **메뉴** | `tool_get_menu_detail` | 메뉴 상세 + 옵션 그룹 조회 |
+| **메뉴** | `tool_filter_menus` | 17개 파라미터 복합 필터 (칼로리·가격·알레르기·층·식당명 등) |
+| **장바구니** | `tool_add_cart_item` | 메뉴 담기 (옵션 포함) |
+| **장바구니** | `tool_get_cart` | 장바구니 전체 조회 |
+| **장바구니** | `tool_update_cart_item` | 수량 수정 |
+| **장바구니** | `tool_remove_cart_item` | 아이템 삭제 |
+| **주문** | `tool_confirm_order` | 장바구니 → 주문 확정 |
+| **결제** | `tool_request_payment` | IC_CARD / VEIN_AUTH 결제 요청 |
+| **세션** | `tool_complete_session` | 주문 세션 종료 |
 
-```bash
-# 1. 의존성 설치
-pip install -r requirements.txt
+### 3-3. LangGraph 기반 AI 에이전트 그래프
 
-# 2. 환경변수 설정
-cp .env.example .env
-# .env 파일에서 SPRING_BASE_URL, OPENAI_API_KEY 수정
+사용자 발화를 받아 의도에 따라 에이전트를 분기하는 그래프를 설계했다.
 
-# 3. 서버 실행
-uvicorn app.main:app --reload
-
-# 4. 확인
-GET http://localhost:8000/health  →  {"status": "ok"}
+```
+입력 ──> [의도 분류기]
+              │
+    ┌─────────┼──────────┬──────────┐
+    ▼         ▼          ▼          ▼
+ 주문 에이전트 결제 에이전트 추천 에이전트 눈치 감지기
+                                        │
+                                        ▼
+                                   추천 에이전트
 ```
 
+**눈치(NUNCHI) 기능**: 사용자가 명시적 요청 없이도 망설임 신호(체류시간, 반복탐색, 침묵, 헤징 발화)를 감지해 먼저 추천을 제안한다.
+
+### 3-4. 계층 분리 설계
+
+```
+kiosk_mcp/mcp_server.py   ← MCP Tool 진입점 (FastMCP 서버)
+kiosk_mcp/tools/*.py      ← Tool 비즈니스 로직 (순수 함수)
+adapter/spring_adapter.py ← Spring API HTTP 클라이언트
+domain/*.py               ← Pydantic 도메인 모델
+```
+
+Tool 로직과 MCP 진입점을 분리해, LangGraph 에이전트와 Claude Desktop 양쪽에서 동일한 비즈니스 로직을 재사용한다.
+
 ---
 
-## 다음 단계
+## 4. Claude Desktop에서 이 프로젝트에 접근하는 방법
 
-1. `spring_adapter.py`로 실제 Spring API 호출 연결 및 테스트
-2. MCP Tool 함수 내부 로직 구현 (session → menu → cart → order → payment)
-3. `agent_service.py` LLM + Tool 체이닝 구현
-4. `voice_pipeline.py` 음성 파이프라인 연결
+### 연결 원리
+
+Claude Desktop은 MCP 서버를 **로컬 프로세스로 직접 실행**한다.  
+설정 파일(`claude_desktop_config.json`)에 MCP 서버 실행 커맨드를 등록하면,  
+Claude Desktop이 앱 시작 시 해당 프로세스를 띄우고 `stdin/stdout`으로 통신한다.
+
+```
+Claude Desktop
+    │  앱 시작 시 자동 실행
+    ▼
+python -m kiosk_mcp.mcp_server  (stdio 모드)
+    │  HTTP REST
+    ▼
+Spring Boot (localhost:8080)
+    │
+    ▼
+PostgreSQL (실제 메뉴·주문 데이터)
+```
+
+### 실제 등록한 설정 (`claude_desktop_config.json`)
+
+```json
+"nunchi-kiosk": {
+  "command": "/Users/hyodongg/Desktop/workspace/capstone_ai/venv/bin/python",
+  "args": ["-m", "kiosk_mcp.mcp_server"],
+  "cwd": "/Users/hyodongg/Desktop/workspace/capstone_ai",
+  "env": {
+    "MCP_TRANSPORT": "stdio",
+    "PYTHONPATH": "/Users/hyodongg/Desktop/workspace/capstone_ai",
+    "SPRING_BASE_URL": "http://localhost:8080"
+  }
+}
+```
+
+- `MCP_TRANSPORT=stdio` → Claude Desktop용 stdio 모드로 서버 기동
+- `SPRING_BASE_URL` → 로컬에서 실행 중인 Spring 서버에 연결
+- `venv/bin/python` → 프로젝트 가상환경의 파이썬 직접 지정
+
+### 동작 확인
+
+등록 후 Claude Desktop에서:
+
+```
+"오늘 잘 팔리는 메뉴 3개 추천해줘"
+```
+
+→ Claude가 `tool_get_top_menus(limit=3)` 호출  
+→ MCP 서버가 Spring `/api/menus/top` 호출  
+→ 실제 DB 판매 데이터 기반 추천 반환
+
+```
+"비건 메뉴 중에 5000원 이하짜리 알려줘"
+```
+
+→ `tool_filter_menus(vegetarian_type="VEGAN", max_price=5000)` 호출  
+→ Spring `/api/menus/filter` 파라미터 전달 → 실제 필터 결과 반환
+
+---
+
+## 5. 개발 및 배포 환경 분리
+
+| 환경 | Spring | FastAPI | MCP 서버 |
+|------|--------|---------|---------|
+| **로컬 개발** | IntelliJ 직접 실행 | VS Code 직접 실행 | 터미널 직접 실행 |
+| **배포** | Docker Compose | Docker Compose | 동일 이미지, 다른 커맨드 |
+
+```yaml
+# docker-compose.yml 개념
+services:
+  spring: ...
+  fastapi:
+    image: capstone-ai
+    command: uvicorn app.main:app
+  mcp:
+    image: capstone-ai          # FastAPI와 동일 이미지
+    command: python -m kiosk_mcp.mcp_server
+    environment:
+      MCP_TRANSPORT: sse        # 배포에서는 SSE
+```
+
+환경 분리는 `.env.local`(로컬) / `.env`(배포) 파일로만 관리한다.
+
+---
+
+## 6. 핵심 성과
+
+### 기술 성과
+
+- **이중 접근 구조 실현**: 동일한 MCP 서버를 키오스크(SSE) + Claude Desktop(stdio) 양쪽에서 동시 접근 가능
+- **14개 MCP Tool 구현**: 메뉴 조회부터 주문·결제·세션 종료까지 전체 주문 플로우를 Tool로 커버
+- **17개 필터 파라미터**: 칼로리, 가격, 알레르기, 채식 유형, 층, 식당명 등 복합 조건 필터링
+- **LangGraph 에이전트 그래프**: 의도 분류 → 에이전트 분기 → 눈치 감지 → 추천 흐름 자동화
+- **계층 분리**: Tool 로직 / MCP 진입점 / Adapter / Domain을 명확히 분리해 테스트·재사용 용이
+
+### 시연 임팩트
+
+- Claude Desktop에서 자연어 한 마디로 실제 DB 데이터 기반 주문 시연 가능
+- 매장 키오스크(음성 주문) + 외부 Claude Desktop(채팅 주문) 동시 지원
+
+### 기술 스택
+
+`FastAPI` `FastMCP` `LangGraph` `OpenAI API` `Spring Boot` `PostgreSQL`  
+`Docker` `AWS EC2` `GitHub Actions (CI/CD)`

--- a/adapter/spring_adapter.py
+++ b/adapter/spring_adapter.py
@@ -7,14 +7,14 @@ from typing import Optional
 import httpx
 
 from adapter.ports import SpringPort
-from core.config import Settings
+from core.config import _SpringBaseSettings
 from core.exceptions import SpringApiError, SpringApiTimeoutError
 
 
 class SpringAdapter(SpringPort):
     """Spring 백엔드 HTTP 연동"""
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(self, settings: _SpringBaseSettings) -> None:
         self._client = httpx.AsyncClient(
             base_url=settings.spring_base_url,
             timeout=settings.spring_timeout,

--- a/core/config.py
+++ b/core/config.py
@@ -27,3 +27,21 @@ class Settings(BaseSettings):
 @lru_cache
 def get_settings() -> Settings:
     return Settings()
+
+
+class McpSettings(BaseSettings):
+    """MCP 서버 전용 설정 — OpenAI 키 불필요."""
+    spring_base_url: str = "http://localhost:8080"
+    spring_timeout: int = Field(default=5, ge=1)
+
+    model_config = SettingsConfigDict(
+        env_file=(".env", ".env.local"),
+        env_file_encoding="utf-8",
+        populate_by_name=True,
+        extra="ignore",
+    )
+
+
+@lru_cache
+def get_mcp_settings() -> McpSettings:
+    return McpSettings()

--- a/core/config.py
+++ b/core/config.py
@@ -4,17 +4,10 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):
-    # Spring 백엔드
+class _SpringBaseSettings(BaseSettings):
+    """Spring 연동에 필요한 공통 설정."""
     spring_base_url: str = "http://localhost:8080"
     spring_timeout: int = Field(default=5, ge=1)
-
-    # OpenAI
-    openai_api_key: str = Field(min_length=1, alias="OPEN_API_KEY")
-    openai_model: str = "gpt-4o-mini"
-
-    # MCP 서버
-    mcp_server_url: str = "http://localhost:8090"
 
     model_config = SettingsConfigDict(
         env_file=(".env", ".env.local"),  # 로컬 우선, 배포는 .env
@@ -24,22 +17,22 @@ class Settings(BaseSettings):
     )
 
 
+class Settings(_SpringBaseSettings):
+    # OpenAI
+    openai_api_key: str = Field(min_length=1, alias="OPEN_API_KEY")
+    openai_model: str = "gpt-4o-mini"
+
+    # MCP 서버
+    mcp_server_url: str = "http://localhost:8090"
+
+
 @lru_cache
 def get_settings() -> Settings:
     return Settings()
 
 
-class McpSettings(BaseSettings):
+class McpSettings(_SpringBaseSettings):
     """MCP 서버 전용 설정 — OpenAI 키 불필요."""
-    spring_base_url: str = "http://localhost:8080"
-    spring_timeout: int = Field(default=5, ge=1)
-
-    model_config = SettingsConfigDict(
-        env_file=(".env", ".env.local"),
-        env_file_encoding="utf-8",
-        populate_by_name=True,
-        extra="ignore",
-    )
 
 
 @lru_cache

--- a/kiosk_mcp/mcp_server.py
+++ b/kiosk_mcp/mcp_server.py
@@ -16,7 +16,7 @@ from typing import Optional
 from fastmcp import FastMCP
 
 from adapter.spring_adapter import SpringAdapter
-from core.config import get_settings
+from core.config import get_mcp_settings
 from domain.payment import PaymentMethod
 from kiosk_mcp.tools.cart_tools import add_cart_item, get_cart, remove_cart_item, update_cart_item
 from kiosk_mcp.tools.menu_tools import filter_menus, get_categories, get_menu_detail, get_menus, get_top_menus
@@ -25,7 +25,7 @@ from kiosk_mcp.tools.payment_tools import request_payment
 from kiosk_mcp.tools.session_tools import complete_session, create_session, save_message, save_tool_log
 from domain.session import SessionMode
 
-_settings = get_settings()
+_settings = get_mcp_settings()
 _spring = SpringAdapter(_settings)
 
 _INSTRUCTIONS = """


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #19 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
OpenAI 키 없이도 MCP 서버가 기동될 수 있도록 McpSettings를 별도로 분리하고 get_mcp_settings() 작성했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Documentation**
  * MCP 개발 포트폴리오 문서로 전면 교체(아키텍처, 도구 목록, 흐름 설계 포함) 및 초기 세팅 문서 정비
  * 설정 분리 전략과 배포/연결 예시 문서화

* **Refactor**
  * MCP 전용 설정 추가 및 설정 접근 방식 캐시화
  * 어댑터의 설정 의존성 경량화로 구성 구조 분리

* **Chores**
  * 개발 도구 권한 범위 확대(추가적인 git/gh/pip3 등 명령 허용)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->