### PR TITLE
[Refactor] MultiServerMCPClient 싱글톤 전환으로 MCP 연결 재사용

### DIFF
--- a/app/api/order.py
+++ b/app/api/order.py
@@ -50,7 +50,7 @@ async def start_order(
     service: OrderService = Depends(get_order_service),
 ) -> StartOrderResponse:
     """주문 세션을 시작하고 첫 인사 메시지를 반환한다."""
-    return await service.start(mode=body.mode, language=body.language)
+    return await service.start(mode=body.mode, language=body.language, order_type=body.order_type)
 
 
 @router.post(

--- a/app/api/order.py
+++ b/app/api/order.py
@@ -15,7 +15,7 @@ from domain.order_request import (
 )
 from service.order_service import OrderService
 
-router = APIRouter(prefix="/api/order", tags=["order"])
+router = APIRouter(prefix="/order", tags=["order"])
 
 
 @router.post(

--- a/app/api/voice.py
+++ b/app/api/voice.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, status
 
 from domain.api_response import ApiErrorResponse
 
-router = APIRouter(prefix="/api/voice", tags=["voice"])
+router = APIRouter(prefix="/voice", tags=["voice"])
 
 
 @router.post(

--- a/app/main.py
+++ b/app/main.py
@@ -96,8 +96,8 @@ app.add_middleware(
 )
 
 # 라우터 등록
-app.include_router(order.router)
-app.include_router(voice.router)
+app.include_router(order.router, prefix="/ai")
+app.include_router(voice.router, prefix="/ai")
 
 
 # 공통 예외 핸들러

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from adapter.factory import get_spring_adapter
 from app.api import order, voice
 from domain.api_response import ApiErrorResponse, HealthCheckResponse
 from core.exceptions import KioskError, SpringApiError
+from service.mcp_client import initialize_mcp_client
 
 _API_DESCRIPTION = """
 ## 개요
@@ -64,9 +65,8 @@ _OPENAPI_TAGS = [
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # 서버 시작 시 초기화할 것이 있으면 여기에 추가
+    await initialize_mcp_client()
     yield
-    # 공유 HTTP 클라이언트 정리
     await get_spring_adapter().close()
 
 

--- a/domain/order.py
+++ b/domain/order.py
@@ -5,6 +5,7 @@ from enum import Enum
 from pydantic import BaseModel, ConfigDict, Field
 
 from domain.cart import CartItem, CartItemOption
+from domain.session import OrderType
 
 
 class OrderStatus(str, Enum):
@@ -36,4 +37,5 @@ class OrderResult(BaseModel):
     session_id:   int         = Field(alias="sessionId")
     total_amount: int         = Field(alias="totalAmount")
     order_status: OrderStatus = Field(alias="orderStatus")
+    order_type:   OrderType   = Field(alias="orderType")
     items:        list[OrderItem] = Field(default_factory=list)

--- a/domain/order_request.py
+++ b/domain/order_request.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from domain.session import SessionMode
+from domain.session import OrderType, SessionMode
 
 
 class StartOrderRequest(BaseModel):
@@ -17,6 +17,7 @@ class StartOrderRequest(BaseModel):
             "example": {
                 "mode": "AVATAR",
                 "language": "ko",
+                "order_type": "DINE_IN",
             }
         }
     )
@@ -34,6 +35,11 @@ class StartOrderRequest(BaseModel):
         default="ko",
         description="세션에서 사용할 언어 코드입니다. 현재 기본값은 한국어(`ko`)입니다.",
         examples=["ko"],
+    )
+    order_type: OrderType = Field(
+        default=OrderType.dine_in,
+        description="주문 유형입니다. `DINE_IN`은 매장 식사, `TAKEOUT`은 포장입니다.",
+        examples=["DINE_IN"],
     )
 
 

--- a/domain/session.py
+++ b/domain/session.py
@@ -15,6 +15,11 @@ class SessionStatus(str, Enum):
     expired   = "EXPIRED"
 
 
+class OrderType(str, Enum):
+    dine_in = "DINE_IN"
+    takeout = "TAKEOUT"
+
+
 class SessionResult(BaseModel):
     """POST /api/sessions 응답"""
 
@@ -24,4 +29,5 @@ class SessionResult(BaseModel):
     mode: SessionMode
     status: SessionStatus
     language: str
+    order_type: OrderType = Field(alias="orderType")
     created_at: datetime = Field(alias="createdAt")

--- a/kiosk_mcp/mcp_server.py
+++ b/kiosk_mcp/mcp_server.py
@@ -48,9 +48,11 @@ mcp_app = FastMCP("nunchi-kiosk", instructions=_INSTRUCTIONS)
 # ─── 세션 시작 / 대화 저장 Tool ──────────────────────────────────────────────
 
 @mcp_app.tool()
-async def tool_create_session(language: str = "ko") -> str:
-    """대화 세션을 시작한다. 반드시 대화 첫 번째로 호출해야 한다. session_id를 반환한다."""
-    result = await create_session(_spring, mode=SessionMode.avatar, language=language)
+async def tool_create_session(language: str = "ko", order_type: str = "DINE_IN") -> str:
+    """대화 세션을 시작한다. 반드시 대화 첫 번째로 호출해야 한다. session_id를 반환한다. order_type은 DINE_IN(매장) 또는 TAKEOUT(포장)."""
+    from domain.session import OrderType
+    ot = OrderType(order_type.upper())
+    result = await create_session(_spring, mode=SessionMode.avatar, language=language, order_type=ot)
     return json.dumps({"session_id": result.session_id}, ensure_ascii=False)
 
 

--- a/kiosk_mcp/tools/session_tools.py
+++ b/kiosk_mcp/tools/session_tools.py
@@ -4,16 +4,17 @@ import logging
 
 from adapter.spring_adapter import SpringAdapter
 from domain.conversation import ConversationMessage
-from domain.session import SessionMode, SessionResult
+from domain.session import OrderType, SessionMode, SessionResult
 
 
 async def create_session(
     spring: SpringAdapter,
     mode: SessionMode = SessionMode.avatar,
     language: str = "ko",
+    order_type: OrderType = OrderType.dine_in,
 ) -> SessionResult:
     """주문 세션 시작 — POST /api/sessions"""
-    data = await spring.post("/api/sessions", {"mode": mode.value, "language": language})
+    data = await spring.post("/api/sessions", {"mode": mode.value, "language": language, "orderType": order_type.value})
     try:
         return SessionResult.model_validate(data)
     except Exception as exc:

--- a/service/graph/nodes/order_node.py
+++ b/service/graph/nodes/order_node.py
@@ -4,12 +4,12 @@
 MultiServerMCPClient로 FastMCP 서버에 연결해 Tool 목록을 가져온다.
 """
 
-from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from core.config import get_settings
 from service.graph.state import KioskState
+from service.mcp_client import get_mcp_tools
 
 _ORDER_SYSTEM_PROMPT = """
 너는 키오스크 주문 AI 어시스턴트다.
@@ -82,10 +82,7 @@ async def run_order_agent(state: KioskState) -> dict:
 
     llm = ChatOpenAI(model=s.openai_model, api_key=s.openai_api_key, temperature=0.3)
 
-    client = MultiServerMCPClient(
-        {"kiosk": {"url": f"{s.mcp_server_url}/sse", "transport": "sse"}}
-    )
-    tools = await client.get_tools()
+    tools = get_mcp_tools()
     agent = create_react_agent(llm, tools, prompt=system_prompt)
     result = await agent.ainvoke({"messages": state["messages"]})
 

--- a/service/graph/nodes/order_node.py
+++ b/service/graph/nodes/order_node.py
@@ -1,7 +1,7 @@
 """주문 에이전트 노드
 
 메뉴 탐색, 장바구니 담기/수정/삭제를 처리하는 ReAct 에이전트.
-MultiServerMCPClient로 FastMCP 서버에 연결해 Tool 목록을 가져온다.
+초기화 시 캐싱된 MCP Tool 목록(get_mcp_tools)을 재사용한다.
 """
 
 from langchain_openai import ChatOpenAI

--- a/service/graph/nodes/payment_node.py
+++ b/service/graph/nodes/payment_node.py
@@ -4,12 +4,12 @@
 흐름을 순서대로 처리하는 ReAct 에이전트.
 """
 
-from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from core.config import get_settings
 from service.graph.state import KioskState
+from service.mcp_client import get_mcp_tools
 
 _PAYMENT_SYSTEM_PROMPT = """
 너는 키오스크 결제 AI 어시스턴트다.
@@ -40,10 +40,7 @@ async def run_payment_agent(state: KioskState) -> dict:
 
     llm = ChatOpenAI(model=s.openai_model, api_key=s.openai_api_key, temperature=0)
 
-    client = MultiServerMCPClient(
-        {"kiosk": {"url": f"{s.mcp_server_url}/sse", "transport": "sse"}}
-    )
-    tools = await client.get_tools()
+    tools = get_mcp_tools()
     agent = create_react_agent(llm, tools, prompt=prompt)
     result = await agent.ainvoke({"messages": state["messages"]})
 

--- a/service/graph/nodes/recommend_node.py
+++ b/service/graph/nodes/recommend_node.py
@@ -4,12 +4,12 @@
 눈치 감지 노드(nunchi_node)에서도 이 노드로 연결된다.
 """
 
-from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from core.config import get_settings
 from service.graph.state import KioskState
+from service.mcp_client import get_mcp_tools
 
 _RECOMMEND_SYSTEM_PROMPT = """
 너는 키오스크 메뉴 추천 AI 어시스턴트다.
@@ -60,10 +60,7 @@ async def run_recommend_agent(state: KioskState) -> dict:
 
     llm = ChatOpenAI(model=s.openai_model, api_key=s.openai_api_key, temperature=0.5)
 
-    client = MultiServerMCPClient(
-        {"kiosk": {"url": f"{s.mcp_server_url}/sse", "transport": "sse"}}
-    )
-    tools = await client.get_tools()
+    tools = get_mcp_tools()
     agent = create_react_agent(llm, tools, prompt=_RECOMMEND_SYSTEM_PROMPT)
     result = await agent.ainvoke({"messages": state["messages"]})
 

--- a/service/mcp_client.py
+++ b/service/mcp_client.py
@@ -15,14 +15,18 @@ _tools: list[BaseTool] | None = None
 
 async def initialize_mcp_client() -> None:
     global _client, _tools
+    if _client is not None and _tools is not None:
+        return
     s = get_settings()
-    _client = MultiServerMCPClient(
+    client = MultiServerMCPClient(
         {"kiosk": {"url": f"{s.mcp_server_url}/sse", "transport": "sse"}}
     )
-    _tools = await _client.get_tools()
+    tools = await client.get_tools()
+    _client = client
+    _tools = tools
 
 
 def get_mcp_tools() -> list[BaseTool]:
     if _tools is None:
         raise RuntimeError("MCP 클라이언트가 초기화되지 않았습니다. lifespan에서 initialize_mcp_client()를 먼저 호출하세요.")
-    return _tools
+    return list(_tools)

--- a/service/mcp_client.py
+++ b/service/mcp_client.py
@@ -1,0 +1,28 @@
+"""MCP 클라이언트 싱글톤
+
+서버 시작 시 한 번만 SSE 연결해 tool 목록을 캐싱한다.
+이후 요청은 캐시된 리스트를 즉시 반환해 SSE 핸드셰이크 오버헤드를 제거한다.
+"""
+
+from langchain_core.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+from core.config import get_settings
+
+_client: MultiServerMCPClient | None = None
+_tools: list[BaseTool] | None = None
+
+
+async def initialize_mcp_client() -> None:
+    global _client, _tools
+    s = get_settings()
+    _client = MultiServerMCPClient(
+        {"kiosk": {"url": f"{s.mcp_server_url}/sse", "transport": "sse"}}
+    )
+    _tools = await _client.get_tools()
+
+
+def get_mcp_tools() -> list[BaseTool]:
+    if _tools is None:
+        raise RuntimeError("MCP 클라이언트가 초기화되지 않았습니다. lifespan에서 initialize_mcp_client()를 먼저 호출하세요.")
+    return _tools

--- a/service/order_service.py
+++ b/service/order_service.py
@@ -12,7 +12,7 @@ from langchain_core.messages import HumanMessage
 
 from adapter.spring_adapter import SpringAdapter
 from domain.order_request import ChatOrderResponse, StartOrderResponse
-from domain.session import SessionMode
+from domain.session import OrderType, SessionMode
 from kiosk_mcp.tools.session_tools import create_session, save_message
 from service.graph.kiosk_graph import build_kiosk_graph
 
@@ -28,9 +28,10 @@ class OrderService:
         self,
         mode: SessionMode = SessionMode.avatar,
         language: str = "ko",
+        order_type: OrderType = OrderType.dine_in,
     ) -> StartOrderResponse:
         """Spring 세션을 생성하고 첫 인사 메시지를 반환한다."""
-        session = await create_session(self._spring, mode, language)
+        session = await create_session(self._spring, mode, language, order_type)
 
         # 첫 인사 — LLM 호출 없이 고정 메시지로 빠르게 응답
         return StartOrderResponse(


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #23 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 매 요청마다 SSE 핸드셰이크가 발생하던 문제를 해결.
- 서버 시작 시 initialize_mcp_client()로 tools를 한 번 fetch해 캐싱하고, order/payment/recommend 세 노드가 get_mcp_tools()로 캐시를 재사용하도록 변경.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * MCP 클라이언트 초기화 메커니즘을 통합하여 애플리케이션 시작 시 한 번만 설정되도록 개선
  * 여러 에이전트의 도구 검색 로직을 중앙화하여 시스템 효율성 향상
  * 공유 MCP 클라이언트 헬퍼를 통해 중복 제거 및 리소스 관리 최적화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI-AI/pull/29)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->