### PR TITLE
[Refactor] 프론트 아바타 구현 모드를 위한 요청사항 반영

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -89,6 +89,7 @@ app.add_middleware(
         "http://localhost:8080",
         "http://localhost:5173",
         "http://localhost:3000",
+        "http://127.0.0.1:8080",
     ],
     allow_credentials=True,
     allow_methods=["*"],

--- a/domain/cart.py
+++ b/domain/cart.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -22,6 +24,7 @@ class CartItem(BaseModel):
     unit_price: int = Field(alias="unitPrice")
     quantity: int
     item_total: int = Field(alias="itemTotal")
+    image_url: Optional[str] = Field(default=None, alias="imageUrl")
     options: list[CartItemOption] = Field(default_factory=list)
 
 

--- a/domain/order_request.py
+++ b/domain/order_request.py
@@ -21,6 +21,32 @@ class RecommendedMenu(BaseModel):
     quantity_sold: Optional[int] = None
 
 
+class MenuOptionItem(BaseModel):
+    """옵션 단일 항목 — 프론트엔드 옵션 선택 UI용"""
+
+    option_id: int
+    name: str
+    extra_price: int
+
+
+class MenuOptionGroup(BaseModel):
+    """옵션 그룹 — 하나의 선택 카테고리 (예: 온도, 사이즈)"""
+
+    group_id: int
+    group_name: str
+    is_required: bool
+    max_select: int
+    options: list[MenuOptionItem]
+
+
+class MenuOptionsResponse(BaseModel):
+    """메뉴 옵션 선택 단계 구조화 응답 — 프론트엔드 옵션 선택 UI 렌더링용"""
+
+    menu_id: int
+    menu_name: str
+    option_groups: list[MenuOptionGroup]
+
+
 class StartOrderRequest(BaseModel):
     """POST /api/order/start 요청"""
 
@@ -123,6 +149,7 @@ class ChatOrderResponse(BaseModel):
             "example": {
                 "session_id": 101,
                 "reply": "오늘 인기 메뉴를 추천해 드릴게요!",
+                "current_step": "BROWSE",
                 "recommendations": [
                     {
                         "menu_id": 13,
@@ -134,6 +161,7 @@ class ChatOrderResponse(BaseModel):
                         "quantity_sold": 50,
                     }
                 ],
+                "menu_options": None,
             }
         }
     )
@@ -146,7 +174,16 @@ class ChatOrderResponse(BaseModel):
         description="AI 안내 멘트. TTS 또는 아바타 대사로 사용한다.",
         examples=["오늘 인기 메뉴를 추천해 드릴게요!"],
     )
+    current_step: Optional[str] = Field(
+        default=None,
+        description="현재 주문 단계. BROWSE / SELECT / CONFIGURE / CHECKOUT 중 하나. 단계 UI 동기화에 사용한다.",
+        examples=["BROWSE"],
+    )
     recommendations: Optional[list[RecommendedMenu]] = Field(
         default=None,
         description="추천 메뉴 카드 목록. 추천 응답일 때만 포함되며 최대 3개. 프론트엔드 카드 렌더링에 사용한다.",
+    )
+    menu_options: Optional[MenuOptionsResponse] = Field(
+        default=None,
+        description="메뉴 옵션 선택 정보. CONFIGURE 단계에서 옵션이 있는 메뉴를 선택했을 때만 포함된다. 프론트엔드 옵션 선택 UI에 사용한다.",
     )

--- a/service/graph/nodes/order_node.py
+++ b/service/graph/nodes/order_node.py
@@ -63,11 +63,13 @@ _ORDER_SYSTEM_PROMPT = """
   → tool_clear_cart(session_id=현재_session_id) 호출
   → "장바구니를 비웠어요. 처음부터 다시 주문해 드릴게요!" 응답
 
-[메뉴 옵션 선택 — 구조화 JSON 응답]
+[메뉴 옵션 선택 — 구조화 JSON 응답 ★ 최우선 규칙]
 tool_get_menu_detail 결과에 option_groups 가 1개 이상 있으면
-사용자에게 옵션을 선택받기 위해 반드시 아래 JSON 형식으로 응답해라.
+절대로 자연어로 옵션 목록을 나열하지 마라.
+반드시 아래 JSON 형식 그대로 출력해라. 다른 텍스트는 일절 추가하지 마라.
 장바구니 담기는 사용자가 옵션을 선택한 다음 turn에 수행한다.
 
+```json
 {
   "reply": "옵션을 선택해주세요.",
   "menu_options": {
@@ -86,6 +88,7 @@ tool_get_menu_detail 결과에 option_groups 가 1개 이상 있으면
     ]
   }
 }
+```
 
 규칙:
 - option_groups 가 비어 있으면 JSON 응답 없이 바로 tool_add_cart_item 을 호출해라.

--- a/service/graph/nodes/order_node.py
+++ b/service/graph/nodes/order_node.py
@@ -42,6 +42,20 @@ _ORDER_SYSTEM_PROMPT = """
 [건너뛰기]
 메뉴+수량+결제 의사가 한 발화에 모두 있으면 단계를 무시하고 바로 담기+결제로 진행한다.
 
+[장바구니 조회 / 수정 / 삭제]
+사용자가 "장바구니에 뭐 있어?", "담은 게 뭐야?", "뭐 담았어?" 같이 현재 장바구니를 물으면
+반드시 tool_get_cart(session_id=...) 를 호출한 뒤 그 결과를 기반으로 답해라.
+- 항목이 없으면 "아직 장바구니가 비어 있어요."
+- 항목이 있으면 메뉴명·수량·금액을 가독성 있게 나열하고 총합도 알려줘.
+
+사용자가 특정 메뉴의 수량을 늘리거나 줄이려 하면:
+1. tool_get_cart(session_id=...) 로 해당 item_id를 확보한다.
+2. tool_update_cart_item(session_id=..., item_id=..., quantity=새수량) 으로 수정한다.
+
+사용자가 특정 메뉴를 빼달라고 하면:
+1. tool_get_cart(session_id=...) 로 해당 item_id를 확보한다.
+2. tool_remove_cart_item(session_id=..., item_id=...) 으로 삭제한다.
+
 [장바구니 초기화]
 사용자가 "처음부터", "다시 할게요", "전부 취소", "취소할게요", "리셋" 등을 말하면
 반드시 tool_clear_cart(session_id=...) 를 먼저 호출해 장바구니를 비운 뒤 새 주문을 받는다.
@@ -49,7 +63,32 @@ _ORDER_SYSTEM_PROMPT = """
   → tool_clear_cart(session_id=현재_session_id) 호출
   → "장바구니를 비웠어요. 처음부터 다시 주문해 드릴게요!" 응답
 
+[메뉴 옵션 선택 — 구조화 JSON 응답]
+tool_get_menu_detail 결과에 option_groups 가 1개 이상 있으면
+사용자에게 옵션을 선택받기 위해 반드시 아래 JSON 형식으로 응답해라.
+장바구니 담기는 사용자가 옵션을 선택한 다음 turn에 수행한다.
+
+{
+  "reply": "옵션을 선택해주세요.",
+  "menu_options": {
+    "menu_id": <menuId>,
+    "menu_name": "<메뉴명>",
+    "option_groups": [
+      {
+        "group_id": <groupId>,
+        "group_name": "<그룹명>",
+        "is_required": true,
+        "max_select": 1,
+        "options": [
+          {"option_id": <optionId>, "name": "<옵션명>", "extra_price": <추가금액>}
+        ]
+      }
+    ]
+  }
+}
+
 규칙:
+- option_groups 가 비어 있으면 JSON 응답 없이 바로 tool_add_cart_item 을 호출해라.
 - 메뉴를 장바구니에 담기 전에 반드시 tool_get_menu_detail을 먼저 호출해 옵션을 확인해라.
 - 옵션이 없으면 option_ids는 빈 배열([])로 전달해라.
 - 메뉴명이나 가격을 임의로 만들지 말고 반드시 Tool로 조회한 결과만 사용해라.

--- a/service/order_service.py
+++ b/service/order_service.py
@@ -99,6 +99,31 @@ class OrderService:
         )
 
 
+def _extract_json_block(raw: str) -> Optional[str]:
+    """응답 문자열에서 JSON 블록을 추출한다.
+
+    우선순위:
+    1. ```json ... ``` 블록이 있으면 그 안의 내용만 추출
+    2. 전체 문자열이 JSON이면 그대로 반환
+    3. 없으면 None 반환
+    """
+    text = raw.strip()
+    if "```json" in text:
+        start = text.index("```json") + len("```json")
+        end = text.index("```", start)
+        return text[start:end].strip()
+    if "```" in text:
+        parts = text.split("```")
+        if len(parts) >= 2:
+            candidate = parts[1].strip()
+            if candidate.startswith("json"):
+                candidate = candidate[4:].strip()
+            return candidate
+    if text.startswith("{"):
+        return text
+    return None
+
+
 def _parse_agent_reply(
     raw: str,
 ) -> tuple[str, Optional[list[RecommendedMenu]], Optional[MenuOptionsResponse]]:
@@ -107,15 +132,13 @@ def _parse_agent_reply(
     지원 키:
     - recommendations → 추천 메뉴 카드 목록
     - menu_options     → 옵션 선택 구조화 응답
-    JSON이 아니거나 두 키 모두 없으면 원본 텍스트를 그대로 반환한다.
+    JSON 블록이 없거나 두 키 모두 없으면 원본 텍스트를 그대로 반환한다.
     """
     try:
-        text = raw.strip()
-        if text.startswith("```"):
-            text = text.split("```")[1]
-            if text.startswith("json"):
-                text = text[4:]
-        data = json.loads(text)
+        json_str = _extract_json_block(raw)
+        if json_str is None:
+            return raw, None, None
+        data = json.loads(json_str)
 
         reply = data.get("reply") or data.get("message") or raw
         recommendations: Optional[list[RecommendedMenu]] = None

--- a/service/order_service.py
+++ b/service/order_service.py
@@ -13,7 +13,14 @@ from typing import Optional
 from langchain_core.messages import HumanMessage
 
 from adapter.spring_adapter import SpringAdapter
-from domain.order_request import ChatOrderResponse, RecommendedMenu, StartOrderResponse
+from domain.order_request import (
+    ChatOrderResponse,
+    MenuOptionGroup,
+    MenuOptionItem,
+    MenuOptionsResponse,
+    RecommendedMenu,
+    StartOrderResponse,
+)
 from domain.session import OrderType, SessionMode
 from kiosk_mcp.tools.session_tools import create_session, save_message
 from service.graph.kiosk_graph import build_kiosk_graph
@@ -76,29 +83,65 @@ class OrderService:
             raise RuntimeError("그래프 실행 결과에 메시지가 없습니다")
         raw = messages[-1].content
 
-        # 추천 노드가 JSON을 반환한 경우 파싱해 구조화 응답으로 변환
-        reply, recommendations = _parse_recommend_reply(raw)
+        # JSON 응답 파싱 (추천 / 옵션 구조화 응답)
+        reply, recommendations, menu_options = _parse_agent_reply(raw)
+        current_step = result.get("current_step")
 
         # 2. AI 응답 저장
         await save_message(self._spring, session_id, "ASSISTANT", reply)
 
-        return ChatOrderResponse(session_id=session_id, reply=reply, recommendations=recommendations)
+        return ChatOrderResponse(
+            session_id=session_id,
+            reply=reply,
+            current_step=current_step,
+            recommendations=recommendations,
+            menu_options=menu_options,
+        )
 
 
-def _parse_recommend_reply(raw: str) -> tuple[str, Optional[list[RecommendedMenu]]]:
-    """추천 노드 JSON 응답을 파싱한다. JSON이 아니면 원본 텍스트를 그대로 반환한다."""
+def _parse_agent_reply(
+    raw: str,
+) -> tuple[str, Optional[list[RecommendedMenu]], Optional[MenuOptionsResponse]]:
+    """에이전트 JSON 응답을 파싱한다.
+
+    지원 키:
+    - recommendations → 추천 메뉴 카드 목록
+    - menu_options     → 옵션 선택 구조화 응답
+    JSON이 아니거나 두 키 모두 없으면 원본 텍스트를 그대로 반환한다.
+    """
     try:
         text = raw.strip()
-        # ```json ... ``` 블록 제거
         if text.startswith("```"):
             text = text.split("```")[1]
             if text.startswith("json"):
                 text = text[4:]
         data = json.loads(text)
-        if "recommendations" not in data:
-            return raw, None
-        menus = [RecommendedMenu(**item) for item in data["recommendations"]]
-        return data.get("message", raw), menus
+
+        reply = data.get("reply") or data.get("message") or raw
+        recommendations: Optional[list[RecommendedMenu]] = None
+        menu_options: Optional[MenuOptionsResponse] = None
+
+        if "recommendations" in data:
+            recommendations = [RecommendedMenu(**item) for item in data["recommendations"]]
+
+        if "menu_options" in data:
+            mo = data["menu_options"]
+            menu_options = MenuOptionsResponse(
+                menu_id=mo["menu_id"],
+                menu_name=mo["menu_name"],
+                option_groups=[
+                    MenuOptionGroup(
+                        group_id=g["group_id"],
+                        group_name=g["group_name"],
+                        is_required=g.get("is_required", False),
+                        max_select=g.get("max_select", 1),
+                        options=[MenuOptionItem(**o) for o in g["options"]],
+                    )
+                    for g in mo.get("option_groups", [])
+                ],
+            )
+
+        return reply, recommendations, menu_options
     except Exception:
-        logging.debug("[추천 파싱 스킵] JSON 아님 — 원본 텍스트 반환")
-        return raw, None
+        logging.debug("[에이전트 응답 파싱 스킵] JSON 아님 — 원본 텍스트 반환")
+        return raw, None, None


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #34 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
  - `CartItem`에 `image_url` 필드 추가 — Spring `imageUrl` 연동으로 미니카트 메뉴 이미지 표시
  - `/ai/order/chat` 응답에 `current_step` 추가 — 프론트 단계 UI 동기화
  - `/ai/order/chat` 응답에 `menu_options` 추가 — 옵션 있는 메뉴 선택 시 key/value 구조화 응답 제공
  - 에이전트 장바구니 조회/수정/삭제 시나리오 프롬프트 추가 — "장바구니에 뭐 있어?" 정상 응답

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
  - `menu_options`는 옵션이 있는 메뉴일 때만 포함되고, 없으면 `null`
  - 장바구니 조회/수정/삭제 MCP 툴은 이미 구현돼 있었고 에이전트 프롬프트에 시나리오만 추가함

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
