### PR TITLE
[Feat] 음성 원격조작 — action 응답 채널 + clarify intent + 노드 UI 지침

### DIFF
--- a/domain/order_request.py
+++ b/domain/order_request.py
@@ -193,6 +193,20 @@ class ChatOrderResponse(BaseModel):
         description="다음 발화 추천 문구 최대 3개. 프론트엔드 퀵바 버튼 렌더링에 사용한다. 버튼 클릭 시 해당 문자열을 text로 그대로 전달한다.",
         examples=[["다른 메뉴도 추천해줘", "장바구니 확인해줘", "결제할게"]],
     )
+    action: Optional[dict] = Field(
+        default=None,
+        description=(
+            "프론트가 받아 화면을 직접 컨트롤하는 단일 액션. "
+            "노드가 필요 시 채우며, 없으면 None. 프론트의 AiAction.handle()이 dispatch한다. "
+            "지원 타입: navigate / select_floor / select_restaurant / highlight_menu / "
+            "open_menu_detail / close_overlay / select_payment_method."
+        ),
+        examples=[
+            {"type": "navigate", "page": "/summary"},
+            {"type": "highlight_menu", "menu_id": 22},
+            {"type": "select_payment_method", "method": "barcode"},
+        ],
+    )
 
 
 class AddCartItemRequest(BaseModel):

--- a/service/graph/kiosk_graph.py
+++ b/service/graph/kiosk_graph.py
@@ -7,6 +7,7 @@ OrderService가 이 그래프를 ainvoke()로 실행한다.
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, StateGraph
 
+from service.graph.nodes.clarify_node import run_clarify_node
 from service.graph.nodes.intent_node import classify_intent, route_by_intent
 from service.graph.nodes.nunchi_node import detect_nunchi
 from service.graph.nodes.order_node import run_order_agent
@@ -26,6 +27,7 @@ def _build_graph(with_checkpointer: bool = True):
     graph.add_node("payment_agent",      run_payment_agent)
     graph.add_node("recommend_agent",    run_recommend_agent)
     graph.add_node("nunchi_detector",    detect_nunchi)
+    graph.add_node("clarify_responder",  run_clarify_node)
     graph.add_node("step_transition",    transition_step)
 
     # ainvoke()호출 시 항상 여기서 시작
@@ -41,15 +43,17 @@ def _build_graph(with_checkpointer: bool = True):
             "payment":    "payment_agent",
             "recommend":  "recommend_agent",
             "hesitation": "nunchi_detector",
+            "clarify":    "clarify_responder",   # OOD/인사/모호 발화
         },
     )
 
     # 고정 경로 설계
-    graph.add_edge("nunchi_detector",  "recommend_agent")
-    graph.add_edge("order_agent",      "step_transition")
-    graph.add_edge("recommend_agent",  "step_transition")
-    graph.add_edge("step_transition",  END)
-    graph.add_edge("payment_agent",    END)
+    graph.add_edge("nunchi_detector",   "recommend_agent")
+    graph.add_edge("order_agent",       "step_transition")
+    graph.add_edge("recommend_agent",   "step_transition")
+    graph.add_edge("clarify_responder", END)
+    graph.add_edge("step_transition",   END)
+    graph.add_edge("payment_agent",     END)
 
     if with_checkpointer:
         return graph.compile(checkpointer=MemorySaver())

--- a/service/graph/nodes/clarify_node.py
+++ b/service/graph/nodes/clarify_node.py
@@ -1,0 +1,67 @@
+"""OOD/인사/모호 발화에 대한 응답 노드.
+
+intent_node 가 'clarify' 로 분류한 발화를 받아 "메뉴 주문 관련해서만 도와드릴 수 있어요" 같은
+짧은 안내 응답을 생성한다.
+
+LLM 호출 없이 정해진 안내 멘트를 반환해 비용·지연을 줄인다.
+"""
+
+import logging
+
+from langchain_core.messages import AIMessage
+
+from service.graph.state import KioskState
+
+# 가벼운 응답 풀 — 발화 유형에 따라 다른 멘트 선택 (기본은 메뉴 안내)
+_CLARIFY_REPLIES = {
+    "greeting": (
+        "안녕하세요! 무엇을 도와드릴까요? "
+        "메뉴를 추천해드릴까요, 아니면 직접 골라보시겠어요?"
+    ),
+    "default": (
+        "죄송해요, 메뉴 주문과 관련된 요청만 도와드릴 수 있어요. "
+        "메뉴 추천이나 주문을 말씀해 주세요."
+    ),
+}
+
+# 단순 인사 패턴 (LLM 안 거치고도 빠르게 매칭)
+_GREETING_KEYWORDS = ("안녕", "처음이야", "처음입니다", "안녕하세요", "헬로", "하이")
+
+
+def _pick_reply(user_text: str) -> str:
+    """사용자 발화 문자열 기반으로 적절한 안내 멘트를 고른다."""
+    t = (user_text or "").strip().lower()
+    if any(k in t for k in _GREETING_KEYWORDS):
+        return _CLARIFY_REPLIES["greeting"]
+    return _CLARIFY_REPLIES["default"]
+
+
+async def run_clarify_node(state: KioskState) -> dict:
+    """OOD/인사/모호 발화에 짧은 안내 응답을 채워 반환한다."""
+    last_user_text = ""
+    for msg in reversed(state.get("messages") or []):
+        # HumanMessage 우선
+        content = getattr(msg, "content", "")
+        if msg.__class__.__name__ == "HumanMessage" and isinstance(content, str):
+            last_user_text = content
+            break
+
+    reply_text = _pick_reply(last_user_text)
+    logging.debug("[clarify_node] 입력=%r → reply=%r", last_user_text, reply_text)
+
+    # 응답을 JSON 형식으로 — order_service 의 _parse_agent_reply 가 파싱할 수 있게
+    import json
+    payload = {
+        "reply": reply_text,
+        "suggestions": [
+            "메뉴 추천해줘",
+            "메뉴 직접 볼게",
+            "처음부터 다시 할게",
+        ],
+        "action": None,
+    }
+    return {
+        "messages": [AIMessage(content=json.dumps(payload, ensure_ascii=False))],
+        # 현재 단계 그대로 유지 (BROWSE 가 기본)
+        "current_step": state.get("current_step") or "BROWSE",
+    }

--- a/service/graph/nodes/intent_node.py
+++ b/service/graph/nodes/intent_node.py
@@ -15,7 +15,7 @@ from service.graph.state import KioskState
 
 _INTENT_SYSTEM_PROMPT = """
 너는 키오스크 AI의 의도 분류기다.
-사용자의 발화를 보고 아래 4가지 중 하나만 반환해라. 다른 말은 절대 하지 마라.
+사용자의 발화를 보고 아래 5가지 중 하나만 반환해라. 다른 말은 절대 하지 마라.
 
 - order      : 메뉴 탐색, 장바구니 담기/수정/삭제, 메뉴 문의, 장바구니 초기화 요청("처음부터", "다시 할게요", "취소"),
                옵션/추가 항목 거절("계란 추가 안 할게", "옵션 없이", "그냥 줘", "기본으로")
@@ -23,6 +23,9 @@ _INTENT_SYSTEM_PROMPT = """
                더 이상 주문할 메뉴가 없다는 명확한 의사 표현("없어요", "됐어요", "그게 다야", "다 됐어요", "이게 다야")
 - recommend  : 추천 요청, 뭐가 맛있냐, 인기 메뉴가 뭐냐, 조건 기반 추천 요청
 - hesitation : 망설임, 침묵 후 재개, "음...", "뭐가 좋지", 결정 못 하는 발화
+- clarify    : 키오스크 주문과 무관한 발화 (날씨/시간/잡담/욕설/광고/의미 불명),
+               단순 인사("안녕", "안녕하세요", "처음이야"),
+               단어 나열만 있고 의도가 불명확("국밥 삶기", "맛있는 거" 같은 모호한 한 마디)
 
 판단 기준 (우선순위 순):
 - "카드", "정맥", "결제" 단어가 포함된 발화는 반드시 payment 로 분류한다.
@@ -30,6 +33,7 @@ _INTENT_SYSTEM_PROMPT = """
 - "없어요", "됐어요", "그게 다야", "다 됐어요" 는 대화 맥락상 추가 주문이 없다는 확정 발화이면 payment, 옵션 거절이면 order 로 분류한다.
 - "처음부터", "다시 할게요", "전부 취소" 는 order 로 분류한다.
 - "아니요" 단독 발화는 대화 맥락을 보고 판단하되, 옵션 선택 중이면 order 로 분류한다.
+- 단순 인사("안녕") · 키오스크와 무관한 잡담 · 의미 불명 단어 나열은 반드시 clarify 로 분류한다.
 """.strip()
 
 
@@ -58,8 +62,8 @@ async def classify_intent(state: KioskState) -> dict:
     ])
 
     intent = response.content.strip().lower()
-    if intent not in ("order", "payment", "recommend", "hesitation"):
-        intent = "order"  # 분류 실패 시 기본값
+    if intent not in ("order", "payment", "recommend", "hesitation", "clarify"):
+        intent = "clarify"  # 분류 실패 시 기본값 (OOD 발화로 간주)
 
     logging.debug("[의도 분류] 입력: %r → intent: %s", last_message.content, intent)
 

--- a/service/graph/nodes/order_node.py
+++ b/service/graph/nodes/order_node.py
@@ -109,10 +109,18 @@ tool_get_menu_detail 결과에 option_groups 가 1개 이상 있으면
 - 장바구니 수정/삭제 후: ["장바구니 확인해줘", "결제할게", "메뉴 더 추가할게"]
 - 장바구니 초기화 후: ["메뉴 추천해줘", "메뉴 직접 볼게", "처음부터 다시 할게"]
 
+화면 액션(action) 규칙 — 명확한 화면 의도가 있을 때만 사용:
+- 사용자가 "장바구니 보여줘/장바구니 확인" 발화하면: {"type": "navigate", "page": "/summary"}
+- 사용자가 "결제할게/주문 확인 완료" 발화하면: {"type": "navigate", "page": "/summary"}
+- 사용자가 특정 메뉴 상세를 묻는 경우(예: "치즈라면 자세히 보여줘"): {"type": "open_menu_detail", "menu_id": <ID>}
+- 사용자가 특정 층/식당을 명시하면: {"type": "select_floor", "floor": N} 또는 {"type": "select_restaurant", "name": "..."}
+- 단순 담기/수정/조회는 action 을 null 로 둔다 (화면 전환 불필요).
+
 ```json
 {
   "reply": "<응답 텍스트>",
-  "suggestions": ["<다음 발화 1>", "<다음 발화 2>", "<다음 발화 3>"]
+  "suggestions": ["<다음 발화 1>", "<다음 발화 2>", "<다음 발화 3>"],
+  "action": null
 }
 ```
 

--- a/service/graph/nodes/payment_node.py
+++ b/service/graph/nodes/payment_node.py
@@ -38,11 +38,21 @@ _PAYMENT_SYSTEM_PROMPT = """
 - 결제 진행 중 오류 발생: ["다시 시도할게", "다른 결제 수단으로 할게", "취소할게"]
 - 결제 완료: null
 
+화면 액션(action) 규칙 — 사용자가 명확히 결제 단계로 진입할 때만 사용:
+- 결제 수단 선택 단계 진입 시: {"type": "navigate", "page": "/payment"}
+- 사용자가 "IC카드/카드/신용카드" 선택 시: {"type": "select_payment_method", "method": "ic"}
+- 사용자가 "정맥/정맥인증" 선택 시: {"type": "select_payment_method", "method": "vein"}
+- 사용자가 "카카오페이/카카오바코드/바코드" 선택 시: {"type": "select_payment_method", "method": "barcode"}
+- 결제 완료 후: {"type": "navigate", "page": "/complete"}
+- 결제 실패 시: {"type": "navigate", "page": "/fail"}
+- 사용자가 단순 정보만 묻거나 의도가 모호하면 action 은 null.
+
 출력 형식:
 ```json
 {
   "reply": "<응답 텍스트>",
-  "suggestions": ["<다음 발화 1>", "<다음 발화 2>", "<다음 발화 3>"]
+  "suggestions": ["<다음 발화 1>", "<다음 발화 2>", "<다음 발화 3>"],
+  "action": null
 }
 ```
 """.strip()

--- a/service/graph/nodes/recommend_node.py
+++ b/service/graph/nodes/recommend_node.py
@@ -50,6 +50,13 @@ Tool 선택 기준:
 - recommendations: Tool에서 조회한 실제 값만 채워라. 없는 필드는 null로 둬라.
 - suggestions: 사용자가 다음에 할 법한 발화 3개. recommendations가 있으면 반드시 마지막 항목을 "다른 메뉴도 추천해줘"로 고정하고 나머지 2개는 탐색/장바구니 관련 문구를 넣어라. ("장바구니 확인해줘", "조건 바꿔서 추천해줘" 등)
 
+화면 액션(action) 규칙:
+- recommendations 가 1개 이상이면 첫 메뉴를 강조한다: {"type": "highlight_menu", "menu_id": <첫 추천 메뉴 ID>}
+- 사용자 발화가 특정 층("1층/2층/3층 메뉴") 을 명시하면: {"type": "select_floor", "floor": 1}
+- 사용자 발화가 특정 식당명("솥앤누들/분식당" 등) 을 명시하면: {"type": "select_restaurant", "name": "솥앤누들"}
+- 위 셋이 동시에 해당하면 highlight_menu 를 우선한다.
+- recommendations 가 없거나 명확한 화면 의도가 없으면 action 은 null.
+
 출력 형식:
 {
   "message": "오늘 인기 메뉴를 추천해 드릴게요!",
@@ -64,7 +71,8 @@ Tool 선택 기준:
       "quantity_sold": 50
     }
   ],
-  "suggestions": ["장바구니 확인해줘", "매운 거 빼고 다시 추천해줘", "다른 메뉴도 추천해줘"]
+  "suggestions": ["장바구니 확인해줘", "매운 거 빼고 다시 추천해줘", "다른 메뉴도 추천해줘"],
+  "action": {"type": "highlight_menu", "menu_id": 13}
 }
 """.strip()
 

--- a/service/graph/state.py
+++ b/service/graph/state.py
@@ -11,8 +11,14 @@ class KioskState(TypedDict):
     session_id: int
     mode: str                                # "AVATAR" 또는 "NORMAL"
     current_step: Optional[str]              # "BROWSE" / "SELECT" / "CONFIGURE" / "CHECKOUT" / None
-    intent: Optional[str]                    # 분류된 의도 (order/payment/recommend/hesitation)
+    intent: Optional[str]                    # 분류된 의도 (order/payment/recommend/hesitation/clarify/greeting)
     order_id: Optional[int]                  # confirm_order 후 채워짐
     payment_id: Optional[int]               # request_payment 후 채워짐
     nunchi_signal: Optional[str]             # 눈치 신호 종류 (silence/hesitation/repeat_browse)
     recommended_menu_ids: list[int]          # 추천된 메뉴 ID 목록
+    # 프론트가 받아 화면을 직접 컨트롤하는 단일 액션. 노드가 필요 시 채움.
+    # 예) {"type": "navigate", "page": "/summary"}
+    #     {"type": "highlight_menu", "menu_id": 22}
+    #     {"type": "select_floor", "floor": 1}
+    #     {"type": "select_payment_method", "method": "barcode"}
+    action: Optional[dict]

--- a/service/graph/ui_actions.py
+++ b/service/graph/ui_actions.py
@@ -1,0 +1,126 @@
+"""UI 액션 명세 — LangGraph 응답에 담아 프론트로 보내는 단일 화면 명령.
+
+프론트(NUNCHI) 의 common/ai-action.js 가 받아 dispatch 한다.
+LLM 이 응답 JSON 의 "action" 키로 채우거나, 노드가 직접 state["action"] 에 세팅한다.
+
+규칙:
+- 단일 액션 (배열 X). 한 응답당 한 화면 명령.
+- 알 수 없는 type 은 frontend 가 무시 (warn 만).
+- 검증 실패 시 None 으로 폐기 (서비스 흐름 안 깨지게).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+
+# ─── 허용된 action.type 목록 ──────────────────────────────────────────────
+NAVIGATE             = "navigate"
+SELECT_FLOOR         = "select_floor"
+SELECT_RESTAURANT    = "select_restaurant"
+HIGHLIGHT_MENU       = "highlight_menu"
+OPEN_MENU_DETAIL     = "open_menu_detail"
+CLOSE_OVERLAY        = "close_overlay"
+SELECT_PAYMENT_METHOD = "select_payment_method"
+
+VALID_TYPES = {
+    NAVIGATE,
+    SELECT_FLOOR,
+    SELECT_RESTAURANT,
+    HIGHLIGHT_MENU,
+    OPEN_MENU_DETAIL,
+    CLOSE_OVERLAY,
+    SELECT_PAYMENT_METHOD,
+}
+
+# 페이지 화이트리스트 (navigate)
+VALID_PAGES = {"/menu", "/summary", "/payment", "/barcode", "/complete", "/fail", "/start"}
+
+# 결제 수단 화이트리스트
+VALID_PAYMENT_METHODS = {"ic", "vein", "barcode"}
+
+
+# ─── 헬퍼 생성자 — 노드가 직접 호출해 state["action"] 채울 때 사용 ──
+def navigate(page: str) -> dict:
+    return {"type": NAVIGATE, "page": page}
+
+
+def select_floor(floor: int) -> dict:
+    return {"type": SELECT_FLOOR, "floor": int(floor)}
+
+
+def select_restaurant(name: str) -> dict:
+    return {"type": SELECT_RESTAURANT, "name": str(name)}
+
+
+def highlight_menu(menu_id: int) -> dict:
+    return {"type": HIGHLIGHT_MENU, "menu_id": int(menu_id)}
+
+
+def open_menu_detail(menu_id: int) -> dict:
+    return {"type": OPEN_MENU_DETAIL, "menu_id": int(menu_id)}
+
+
+def close_overlay() -> dict:
+    return {"type": CLOSE_OVERLAY}
+
+
+def select_payment_method(method: str) -> dict:
+    return {"type": SELECT_PAYMENT_METHOD, "method": str(method)}
+
+
+# ─── 검증 — LLM 이 만든 dict 가 유효한지 확인 ─────────────────────────────
+def validate(action: Optional[dict]) -> Optional[dict]:
+    """LLM 이 생성한 action dict 를 검증한다.
+
+    유효하지 않으면 None 반환 (응답에 포함 안 시킴).
+    """
+    if not isinstance(action, dict):
+        return None
+
+    action_type = action.get("type")
+    if action_type not in VALID_TYPES:
+        logging.warning(f"[ui_actions] 알 수 없는 action.type: {action_type}")
+        return None
+
+    # type 별 페이로드 검증
+    if action_type == NAVIGATE:
+        page = action.get("page")
+        if page not in VALID_PAGES:
+            logging.warning(f"[ui_actions] navigate page 불일치: {page}")
+            return None
+        return {"type": NAVIGATE, "page": page}
+
+    if action_type == SELECT_FLOOR:
+        try:
+            floor = int(action.get("floor"))
+        except (TypeError, ValueError):
+            return None
+        if floor not in (1, 2, 3):
+            return None
+        return {"type": SELECT_FLOOR, "floor": floor}
+
+    if action_type == SELECT_RESTAURANT:
+        name = action.get("name")
+        if not isinstance(name, str) or not name.strip():
+            return None
+        return {"type": SELECT_RESTAURANT, "name": name.strip()}
+
+    if action_type in (HIGHLIGHT_MENU, OPEN_MENU_DETAIL):
+        try:
+            menu_id = int(action.get("menu_id"))
+        except (TypeError, ValueError):
+            return None
+        return {"type": action_type, "menu_id": menu_id}
+
+    if action_type == CLOSE_OVERLAY:
+        return {"type": CLOSE_OVERLAY}
+
+    if action_type == SELECT_PAYMENT_METHOD:
+        method = action.get("method")
+        if method not in VALID_PAYMENT_METHODS:
+            return None
+        return {"type": SELECT_PAYMENT_METHOD, "method": method}
+
+    return None

--- a/service/order_service.py
+++ b/service/order_service.py
@@ -101,9 +101,11 @@ class OrderService:
             raise RuntimeError("그래프 실행 결과에 메시지가 없습니다")
         raw = messages[-1].content
 
-        # JSON 응답 파싱 (추천 / 옵션 / 퀵바 suggestions)
-        reply, recommendations, menu_options, suggestions = _parse_agent_reply(raw)
+        # JSON 응답 파싱 (추천 / 옵션 / 퀵바 suggestions / 화면 액션)
+        reply, recommendations, menu_options, suggestions, parsed_action = _parse_agent_reply(raw)
         current_step = result.get("current_step")
+        # 노드가 명시적으로 채운 action 우선, 없으면 LLM 응답 JSON 의 action 사용
+        action = result.get("action") or parsed_action
 
         # 3. AI 응답 저장
         await save_message(self._spring, session_id, "ASSISTANT", reply)
@@ -115,6 +117,7 @@ class OrderService:
             recommendations=recommendations,
             menu_options=menu_options,
             suggestions=suggestions,
+            action=action,
         )
 
         # 4. suggestions가 있으면 백그라운드 프리패치 스케줄링
@@ -163,8 +166,9 @@ class OrderService:
 
             raw = messages[-1].content
             # 결과 파싱
-            reply, recommendations, menu_options, suggestions = _parse_agent_reply(raw)
+            reply, recommendations, menu_options, suggestions, parsed_action = _parse_agent_reply(raw)
             current_step = result.get("current_step")
+            action = result.get("action") or parsed_action
 
             response = ChatOrderResponse(
                 session_id=session_id,
@@ -173,6 +177,7 @@ class OrderService:
                 recommendations=recommendations,
                 menu_options=menu_options,
                 suggestions=suggestions,
+                action=action,
             )
 
             # 캐시에 저장
@@ -240,25 +245,38 @@ def _extract_json_block(raw: str) -> Optional[str]:
 
 def _parse_agent_reply(
     raw: str,
-) -> tuple[str, Optional[list[RecommendedMenu]], Optional[MenuOptionsResponse], Optional[list[str]]]:
+) -> tuple[
+    str,
+    Optional[list[RecommendedMenu]],
+    Optional[MenuOptionsResponse],
+    Optional[list[str]],
+    Optional[dict],
+]:
     """에이전트 JSON 응답을 파싱한다.
 
     지원 키:
     - recommendations → 추천 메뉴 카드 목록
     - menu_options     → 옵션 선택 구조화 응답
     - suggestions      → 퀵바 다음 발화 추천 문구 목록
+    - action           → 프론트가 받아 화면을 컨트롤하는 단일 명령
+                         (navigate / select_floor / highlight_menu /
+                          open_menu_detail / close_overlay /
+                          select_payment_method / select_restaurant)
     JSON 블록이 없거나 지원 키가 없으면 원본 텍스트를 그대로 반환한다.
     """
+    from service.graph.ui_actions import validate as validate_action
+
     try:
         json_str = _extract_json_block(raw)
         if json_str is None:
-            return _strip_markdown(raw), None, None, None
+            return _strip_markdown(raw), None, None, None, None
         data = json.loads(json_str)
 
         reply = _strip_markdown(data.get("reply") or data.get("message") or raw)
         recommendations: Optional[list[RecommendedMenu]] = None
         menu_options: Optional[MenuOptionsResponse] = None
         suggestions: Optional[list[str]] = None
+        action: Optional[dict] = None
 
         if "recommendations" in data:
             recommendations = [RecommendedMenu(**item) for item in data["recommendations"]]
@@ -284,7 +302,11 @@ def _parse_agent_reply(
         if isinstance(raw_suggestions, list):
             suggestions = [s for s in raw_suggestions if isinstance(s, str)][:3] or None
 
-        return reply, recommendations, menu_options, suggestions
+        # action 검증 — 잘못된 타입/페이로드는 None 으로 폐기 (서비스 흐름 안전)
+        if "action" in data:
+            action = validate_action(data["action"])
+
+        return reply, recommendations, menu_options, suggestions, action
     except Exception:
         logging.debug("[에이전트 응답 파싱 스킵] JSON 아님 — 원본 텍스트 반환")
-        return _strip_markdown(raw), None, None, None
+        return _strip_markdown(raw), None, None, None, None


### PR DESCRIPTION
응답 액션 채널 (Phase A)
- KioskState.action: Optional[dict] 추가
- ChatOrderResponse.action: Optional[dict] 추가 (예시·설명 포함)
- order_service.py: _parse_agent_reply 가 5-tuple 반환, 두 호출자가 노드/LLM 응답의 action 을 ChatOrderResponse 로 전달

UI 액션 모듈 (Phase B) — service/graph/ui_actions.py 신규
- 7개 액션 타입 상수 + 헬퍼 생성자 + validate() 검증
- 지원: navigate / select_floor / select_restaurant / highlight_menu / open_menu_detail / close_overlay / select_payment_method
- 페이지 화이트리스트, 결제수단 화이트리스트로 잘못된 payload 폐기

노드 시스템 프롬프트 강화 (Phase C)
- payment_node: 결제 진입 / 결제수단 카드 선택 / 결제 완료/실패 시 적절한 action 지침
- recommend_node: 첫 추천 메뉴 highlight_menu + 층/식당 명시 시 select_floor/select_restaurant
- order_node: 장바구니 화면 이동 / 메뉴 상세 오버레이 오픈 / 단순 담기는 action null

OOD 발화 분기 (Phase C)
- intent_node: 5번째 intent "clarify" 추가, 분류 실패 fallback → clarify (이전엔 order)
- clarify_node 신규 — LLM 호출 없이 정해진 안내 멘트 응답 (인사 키워드 별도)
- kiosk_graph: clarify_responder 노드 등록 + clarify → clarify_responder → END 엣지

후방 호환
- action 없는 노드/응답은 모두 None — 프론트가 무시 가능
- 기존 4개 intent (order/payment/recommend/hesitation) 동작 그대로

## 📣 Related Issue

## 📝 Summary

음성으로 키오스크 화면을 원격 컨트롤할 수 있도록 LangGraph 응답에 화면 명령(`action`) 필드를 추가하고, OOD/인사 발화를 별도 분기(`clarify`)로 처리한다. 프론트(NUNCHI) 의 `AiAction.handle()` 이 이 `action` 을 받아 자동으로 화면을 컨트롤한다.

### 1. 응답 액션 채널 (Phase A)
- `KioskState.action: Optional[dict]` 필드 추가
- `ChatOrderResponse.action: Optional[dict]` 응답 필드 + 예시·설명
- `_parse_agent_reply` 가 LLM JSON 응답의 `action` 키도 파싱 (5-tuple 반환)
- `order_service.py` 두 호출자가 노드 state 의 action 또는 LLM 응답 action 을 `ChatOrderResponse` 로 전달

### 2. UI 액션 모듈 (Phase B) — `service/graph/ui_actions.py` 신규
- 7개 액션 타입 + 검증
  - `navigate` (page: /menu /summary /payment /barcode /complete /fail /start)
  - `select_floor` (1/2/3)
  - `select_restaurant` (name)
  - `highlight_menu` (menu_id)
  - `open_menu_detail` (menu_id)
  - `close_overlay`
  - `select_payment_method` (ic/vein/barcode)
- `validate()` 가 잘못된 type/payload 는 `None` 반환 (서비스 흐름 보호)

### 3. 노드 시스템 프롬프트 강화 (Phase C)
- **payment_node**: 결제 진입 / 결제수단 카드 선택 / 결제 완료·실패 시 적절한 action 지침
- **recommend_node**: 첫 추천 메뉴 `highlight_menu` + 층/식당 명시 시 `select_floor` / `select_restaurant`
- **order_node**: 장바구니 화면 이동 / 메뉴 상세 오버레이 오픈 / 단순 담기는 action null

### 4. OOD 발화 분기 (Phase C)
- `intent_node`: 5번째 intent `clarify` 추가. 분류 실패 fallback `order` → `clarify`
- **`clarify_node` 신규** — LLM 호출 없이 정해진 안내 멘트 응답
  - 인사 키워드("안녕"/"하이" 등) → 환영 멘트
  - 그 외 OOD ("국밥 삶기" 같은 모호 발화, 잡담, 날씨 등) → "메뉴 주문 관련만 도와드릴 수 있어요"
- `kiosk_graph`: `clarify_responder` 노드 등록 + `clarify → clarify_responder → END` 엣지

## 🙏 Question & PR point

- **action 채널은 단일 객체 정책** (배열 X). 한 응답당 한 화면 명령. 충돌 없는 단순한 모델.
- **action 검증**: 잘못된 type / 페이로드는 `validate()` 가 폐기 → 응답에서 `None`. 프론트 사이드 무시. 서비스 흐름 안전.
- **clarify_node 는 LLM 안 부름**: 토큰 절감 + 응답 즉시. 키워드 매칭만으로 인사/OOD 분기.
- **후방 호환**: `action` 필드 없는 노드/응답은 `None` 그대로. 기존 4개 intent 동작 그대로. 프론트가 `action` 없어도 화면 깨지지 않음.
- 운영 nginx `proxy_read_timeout` 늘리는 인프라 작업은 별도 (이번 PR 범위 외)

## 📬 Postman

<!-- 머지 + 자동 배포 후 검증 cURL:

  POST /ai/order/start { mode:NORMAL, language:ko, order_type:DINE_IN }
  
  발화별 응답에 action 채워지는지:
    "안녕"             → clarify 응답 "안녕하세요..." (recommend 추천 X)
    "오늘 날씨 어때"    → clarify 응답 "메뉴 주문 관련만..."
    "국밥 삶기"         → clarify 응답
    "추천해줘"         → recommend + action: { type: highlight_menu, menu_id: N }
    "1층 메뉴 보여줘"  → recommend + action: { type: select_floor, floor: 1 }
    "결제할게"         → payment + action: { type: navigate, page: /payment }
    "카카오페이로 할게" → payment + action: { type: select_payment_method, method: barcode }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * AI가 화면 네비게이션, 층/식당 선택, 메뉴 강조, 결제수단 선택 등의 화면 액션을 직접 수행할 수 있도록 지원
  * 모호한 발화나 키오스크와 무관한 입력에 대해 명확한 안내 응답 제공
  * 화면 액션 유효성 검증 시스템 추가로 안정성 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI-AI/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->