### PR TITLE
[Feat] FastAPI AI 처리 단계별 시간 로깅 추가

### DIFF
--- a/app/api/order.py
+++ b/app/api/order.py
@@ -2,6 +2,8 @@
 
 요청 파싱과 응답 반환만 담당한다. 비즈니스 로직은 OrderService에 위임한다.
 """
+from uuid import uuid4
+from app.core.logging_timer import log_step
 
 from fastapi import APIRouter, Depends
 
@@ -82,13 +84,22 @@ async def start_order(
     },
 )
 async def chat_order(
-    body: ChatOrderRequest, # JSON 파싱
-    service: OrderService = Depends(get_order_service), # 싱글톤 인스턴스 
+        body: ChatOrderRequest,
+        service: OrderService = Depends(get_order_service),
 ) -> ChatOrderResponse:
     """사용자 발화를 AI에게 전달하고 응답을 반환한다."""
-    return await service.handle_chat(
-        session_id=body.session_id, # 세션 ID
-        text=body.text, # 사용자 발화
-        nunchi_signal=body.nunchi_signal, # 눈치 신호
-        mode=body.mode, # AVATAR / NORMAL
-    )
+    request_id = str(uuid4())
+
+    with log_step(
+            "chat_total",
+            request_id=request_id,
+            session_id=body.session_id,
+            mode=body.mode,
+    ):
+        return await service.handle_chat(
+            session_id=body.session_id,
+            text=body.text,
+            nunchi_signal=body.nunchi_signal,
+            mode=body.mode,
+            request_id=request_id,
+        )

--- a/app/core/logging_timer.py
+++ b/app/core/logging_timer.py
@@ -1,0 +1,44 @@
+import logging
+import time
+from contextlib import contextmanager
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def log_step(
+        step: str,
+        request_id: Optional[str] = None,
+        **extra,
+):
+    start = time.perf_counter()
+
+    try:
+        yield
+    except Exception:
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        extra_text = " ".join(f"{key}={value}" for key, value in extra.items())
+
+        message = (
+            f"[AI_STEP] requestId={request_id} "
+            f"step={step} elapsedMs={elapsed_ms} "
+            f"status=FAIL {extra_text}"
+        )
+
+        print(message, flush=True)
+        logger.exception(message)
+        raise
+
+    else:
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        extra_text = " ".join(f"{key}={value}" for key, value in extra.items())
+
+        message = (
+            f"[AI_STEP] requestId={request_id} "
+            f"step={step} elapsedMs={elapsed_ms} "
+            f"status=SUCCESS {extra_text}"
+        )
+
+        print(message, flush=True)
+        logger.info(message)

--- a/domain/order.py
+++ b/domain/order.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel, ConfigDict, Field
 from domain.cart import CartItem, CartItemOption
 from domain.session import OrderType
 
-
 class OrderStatus(str, Enum):
     pending   = "PENDING"
     completed = "COMPLETED"

--- a/service/graph/kiosk_graph.py
+++ b/service/graph/kiosk_graph.py
@@ -6,7 +6,9 @@ OrderService가 이 그래프를 ainvoke()로 실행한다.
 
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, StateGraph
+from typing import Awaitable, Callable, Any
 
+from app.core.logging_timer import log_step
 from service.graph.nodes.clarify_node import run_clarify_node
 from service.graph.nodes.intent_node import classify_intent, route_by_intent
 from service.graph.nodes.nunchi_node import detect_nunchi
@@ -16,19 +18,43 @@ from service.graph.nodes.recommend_node import run_recommend_agent
 from service.graph.nodes.step_node import transition_step
 from service.graph.state import KioskState
 
+async def _run_timed_node(
+        node_name: str,
+        node_func: Callable[[KioskState], Awaitable[dict]],
+        state: KioskState,
+) -> dict:
+    request_id = state.get("request_id")
+    session_id = state.get("session_id")
+
+    with log_step(
+            f"node_{node_name}",
+            request_id=request_id,
+            session_id=session_id,
+    ):
+        return await node_func(state)
+
+
+def _timed_node(
+        node_name: str,
+        node_func: Callable[[KioskState], Awaitable[dict]],
+):
+    async def wrapper(state: KioskState) -> dict:
+        return await _run_timed_node(node_name, node_func, state)
+
+    return wrapper
 
 def _build_graph(with_checkpointer: bool = True):
     # 빈 그래프 생성
     graph = StateGraph(KioskState)
 
     # 노드들 등록
-    graph.add_node("intent_classifier", classify_intent)
-    graph.add_node("order_agent",        run_order_agent)
-    graph.add_node("payment_agent",      run_payment_agent)
-    graph.add_node("recommend_agent",    run_recommend_agent)
-    graph.add_node("nunchi_detector",    detect_nunchi)
-    graph.add_node("clarify_responder",  run_clarify_node)
-    graph.add_node("step_transition",    transition_step)
+    graph.add_node("intent_classifier", _timed_node("intent_classifier", classify_intent))
+    graph.add_node("order_agent",       _timed_node("order_agent", run_order_agent))
+    graph.add_node("payment_agent",     _timed_node("payment_agent", run_payment_agent))
+    graph.add_node("recommend_agent",   _timed_node("recommend_agent", run_recommend_agent))
+    graph.add_node("nunchi_detector",   _timed_node("nunchi_detector", detect_nunchi))
+    graph.add_node("clarify_responder", _timed_node("clarify_responder", run_clarify_node))
+    graph.add_node("step_transition",   _timed_node("step_transition", transition_step))
 
     # ainvoke()호출 시 항상 여기서 시작
     graph.set_entry_point("intent_classifier")

--- a/service/graph/nodes/order_node.py
+++ b/service/graph/nodes/order_node.py
@@ -7,6 +7,7 @@
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
+from app.core.logging_timer import log_step
 from core.config import get_settings
 from core.model_context import get_current_model
 from service.graph.state import KioskState
@@ -163,20 +164,64 @@ _NORMAL_TONE = (
 
 async def run_order_agent(state: KioskState) -> dict:
     """주문/장바구니 ReAct 에이전트를 실행하고 결과를 반환한다."""
-    s = get_settings()
-    session_id = state["session_id"] # state 에서 세션id 꺼내기
-    mode = state.get("mode", "NORMAL") # state에서 mode 꺼내기 
 
-    # 말투 설정
-    tone = _AVATAR_TONE if mode == "AVATAR" else _NORMAL_TONE
-    system_prompt = tone + f"현재 session_id: {session_id}\n\n" + _ORDER_SYSTEM_PROMPT
+    # LangGraph 실행 흐름에서 전달받은 요청 추적 ID
+    # 하나의 /chat 요청 안에서 어떤 단계가 오래 걸렸는지 로그를 묶어서 보기 위해 사용
+    request_id = state.get("request_id")
 
-    # GPT + MCP Tool 묶어서 에이전트 생성
-    llm = ChatOpenAI(model=get_current_model(s.openai_model), api_key=s.openai_api_key, temperature=0.3)
-    tools = get_mcp_tools()
-    agent = create_react_agent(llm, tools, prompt=system_prompt)
+    # state 에서 세션 ID 꺼내기
+    # MCP Tool 호출 시 현재 주문 세션을 식별하는 값으로 사용
+    session_id = state["session_id"]
 
-    # 에이전트 실행
-    result = await agent.ainvoke({"messages": state["messages"]})
+    # state 에서 주문 모드 꺼내기
+    # AVATAR 모드와 NORMAL 모드에 따라 말투 프롬프트를 다르게 적용
+    mode = state.get("mode", "NORMAL")
 
-    return {"messages": result["messages"]}
+    # 프롬프트 준비 시간 측정
+    # 설정값 조회, 말투 선택, system_prompt 조립 구간이 오래 걸리는지 확인
+    with log_step("order_agent_prepare_prompt", request_id=request_id, session_id=session_id):
+        s = get_settings()
+
+        # 말투 설정
+        tone = _AVATAR_TONE if mode == "AVATAR" else _NORMAL_TONE
+        system_prompt = tone + f"현재 session_id: {session_id}\n\n" + _ORDER_SYSTEM_PROMPT
+
+    # LLM 객체 생성 시간 측정
+    # 매 요청마다 ChatOpenAI 객체를 만드는 비용이 큰지 확인
+    with log_step("order_agent_create_llm", request_id=request_id, session_id=session_id):
+        llm = ChatOpenAI(
+            model=get_current_model(s.openai_model),
+            api_key=s.openai_api_key,
+            temperature=0.3,
+        )
+
+    # MCP Tool 목록 조회 시간 측정
+    # get_mcp_tools()가 캐싱된 Tool 목록을 즉시 반환하는지 확인
+    with log_step("order_agent_get_mcp_tools", request_id=request_id, session_id=session_id):
+        tools = get_mcp_tools()
+
+    # ReAct Agent 생성 시간 측정
+    # LLM과 MCP Tool을 묶어 agent를 구성하는 비용 확인
+    with log_step(
+            "order_agent_create_react_agent",
+            request_id=request_id,
+            session_id=session_id,
+            tool_count=len(tools),
+    ):
+        agent = create_react_agent(llm, tools, prompt=system_prompt)
+
+    # ReAct Agent 실행 시간 측정
+    # 실제 LLM 호출, Tool 선택, MCP Tool 호출, 최종 응답 생성이 이 구간에서 수행됨
+    # order_agent 전체 병목의 핵심 후보
+    with log_step(
+            "order_agent_ainvoke",
+            request_id=request_id,
+            session_id=session_id,
+            message_count=len(state["messages"]),
+    ):
+        result = await agent.ainvoke({"messages": state["messages"]})
+
+    # LangGraph 다음 단계로 넘길 결과 생성 시간 측정
+    # agent 실행 결과에서 messages만 추출해 반환
+    with log_step("order_agent_build_result", request_id=request_id, session_id=session_id):
+        return {"messages": result["messages"]}

--- a/service/graph/state.py
+++ b/service/graph/state.py
@@ -16,6 +16,7 @@ class KioskState(TypedDict):
     payment_id: Optional[int]               # request_payment 후 채워짐
     nunchi_signal: Optional[str]             # 눈치 신호 종류 (silence/hesitation/repeat_browse)
     recommended_menu_ids: list[int]          # 추천된 메뉴 ID 목록
+    request_id: Optional[str]
     # 프론트가 받아 화면을 직접 컨트롤하는 단일 액션. 노드가 필요 시 채움.
     # 예) {"type": "navigate", "page": "/summary"}
     #     {"type": "highlight_menu", "menu_id": 22}

--- a/service/order_service.py
+++ b/service/order_service.py
@@ -15,6 +15,7 @@ from typing import Optional
 from langchain_core.messages import HumanMessage
 
 from adapter.spring_adapter import SpringAdapter
+from app.core.logging_timer import log_step
 from core.config import get_settings
 from core.model_context import set_model_override
 from core.prefetch_cache import get_prefetch_cache
@@ -55,11 +56,12 @@ class OrderService:
         )
 
     async def handle_chat(
-        self,
-        session_id: int,
-        text: str,
-        nunchi_signal: Optional[str] = None,
-        mode: str = "NORMAL",
+            self,
+            session_id: int,
+            text: str,
+            nunchi_signal: Optional[str] = None,
+            mode: str = "NORMAL",
+            request_id: Optional[str] = None,
     ) -> ChatOrderResponse:
         """사용자 발화를 받아 그래프를 실행하고 AI 응답을 반환한다.
 
@@ -76,7 +78,8 @@ class OrderService:
             return cached
 
         # 2. 사용자 발화 저장
-        await save_message(self._spring, session_id, "USER", text)
+        with log_step("save_user_message", request_id=request_id, session_id=session_id):
+            await save_message(self._spring, session_id, "USER", text)
 
         # session_id와 messages, nunchi_signal만 넘긴다.
         # order_id / payment_id / intent 등은 그래프 노드가 관리하며
@@ -88,13 +91,15 @@ class OrderService:
             "session_id":    session_id,
             "mode":          mode.upper(),
             "nunchi_signal": nunchi_signal,
+            "request_id":    request_id,
         }
 
         # ainvoke는 그래프를 실행시키는 함수
-        result = await self._graph.ainvoke(
-            initial_state,
-            config={"configurable": {"thread_id": str(session_id)}},
-        )
+        with log_step("langgraph_invoke", request_id=request_id, session_id=session_id):
+            result = await self._graph.ainvoke(
+                initial_state,
+                config={"configurable": {"thread_id": str(session_id)}},
+            )
 
         messages = result.get("messages") or []
         if not messages:
@@ -108,7 +113,8 @@ class OrderService:
         action = result.get("action") or parsed_action
 
         # 3. AI 응답 저장
-        await save_message(self._spring, session_id, "ASSISTANT", reply)
+        with log_step("save_assistant_message", request_id=request_id, session_id=session_id):
+            await save_message(self._spring, session_id, "ASSISTANT", reply)
 
         response = ChatOrderResponse(
             session_id=session_id,


### PR DESCRIPTION
## 📣 Related Issue

- close #50

## 📝 Summary

FastAPI `/ai/order/chat` 내부 처리 흐름에 단계별 시간 로깅을 추가했습니다.

기존에는 Spring 프록시 로그와 Actuator 메트릭을 통해 `/api/ai/order/chat` 요청이 약 18초 소요되는 것만 확인할 수 있었습니다.  
이번 작업에서는 FastAPI 내부에서 어느 구간이 지연되는지 확인할 수 있도록 `[AI_STEP]` 로그를 추가했습니다.

추가된 주요 측정 구간은 다음과 같습니다.

- `/ai/order/chat` 전체 처리 시간
- 사용자 메시지 저장 시간
- LangGraph 전체 실행 시간
- LangGraph node별 실행 시간
- order_agent 내부 처리 시간
- AI 응답 저장 시간

측정 결과, 병목은 `order_agent_ainvoke` 구간으로 확인되었습니다.

예시 측정 결과:

```text
chat_total: 12019ms
langgraph_invoke: 11970ms
node_intent_classifier: 1227ms
node_order_agent: 9904ms
node_step_transition: 829ms
order_agent_ainvoke: 9867ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경 사항

* **개선사항**
  * 주문 처리 흐름의 요청 추적 및 성능 모니터링 기능 강화
  * 각 처리 단계별 실행 시간 자동 측정 및 성공/실패 상태 로깅
  * 주문 상태 관리 모델 확장으로 시스템 안정성과 문제 진단 효율 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CapstoneDgu/NUNCHI-AI/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->