### PR TITLE
[Feat] 로그 요약 스크립트 추

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ REQUEST.md
 reference/
 *.docx
 EXPLAIN.md
+
+# logs
+logs/
+*.log

--- a/scripts/perf_test_chat.sh
+++ b/scripts/perf_test_chat.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASE_URL="${BASE_URL:-http://localhost:8000}"
+COUNT="${COUNT:-3}"
+
+echo "BASE_URL=$BASE_URL"
+echo "COUNT=$COUNT"
+echo
+
+echo "[START] POST /ai/order/start"
+
+START_BODY=$(python - <<'PY'
+import json
+
+print(json.dumps({
+    "mode": "NORMAL",
+    "language": "ko",
+    "order_type": "DINE_IN"
+}, ensure_ascii=True))
+PY
+)
+
+START_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/ai/order/start" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-binary "$START_BODY")
+
+START_RESPONSE_BODY=$(echo "$START_RESPONSE" | sed '$d')
+START_STATUS=$(echo "$START_RESPONSE" | tail -n 1)
+
+echo "HTTP_STATUS=$START_STATUS"
+echo "$START_RESPONSE_BODY"
+echo
+
+if [ "$START_STATUS" != "201" ] && [ "$START_STATUS" != "200" ]; then
+  echo "Failed to start order session."
+  echo "Check logs/fastapi.log for the root cause."
+  exit 1
+fi
+
+SESSION_ID=$(python -c "import sys, json; print(json.load(sys.stdin)['session_id'])" <<< "$START_RESPONSE_BODY")
+
+echo "SESSION_ID=$SESSION_ID"
+echo
+
+for i in $(seq 1 "$COUNT"); do
+  echo "[$i/$COUNT] POST /ai/order/chat"
+
+  CHAT_BODY=$(python - "$SESSION_ID" <<'PY'
+import json
+import sys
+
+session_id = int(sys.argv[1])
+
+print(json.dumps({
+    "session_id": session_id,
+    "text": "recommend popular menu",
+    "nunchi_signal": None,
+    "mode": "NORMAL"
+}, ensure_ascii=True))
+PY
+)
+
+  echo "REQUEST_BODY=$CHAT_BODY"
+
+  CHAT_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/ai/order/chat" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    --data-binary "$CHAT_BODY")
+
+  CHAT_RESPONSE_BODY=$(echo "$CHAT_RESPONSE" | sed '$d')
+  CHAT_STATUS=$(echo "$CHAT_RESPONSE" | tail -n 1)
+
+  echo "HTTP_STATUS=$CHAT_STATUS"
+  echo "$CHAT_RESPONSE_BODY"
+  echo
+
+  if [ "$CHAT_STATUS" != "200" ]; then
+    echo "Chat request failed."
+    echo "Check logs/fastapi.log for the root cause."
+    exit 1
+  fi
+
+  echo "done"
+  echo
+done

--- a/scripts/run_perf_summary.sh
+++ b/scripts/run_perf_summary.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+FASTAPI_LOG="${FASTAPI_LOG:-logs/fastapi.log}"
+MCP_LOG="${MCP_LOG:-logs/mcp.log}"
+
+echo "========================================"
+echo "NUNCHI AI Performance Summary"
+echo "========================================"
+
+python scripts/summary_ai_steps.py "$FASTAPI_LOG"
+echo
+python scripts/summary_mcp_tools.py "$MCP_LOG"

--- a/scripts/summary_ai_steps.py
+++ b/scripts/summary_ai_steps.py
@@ -1,0 +1,63 @@
+import re
+import sys
+from collections import defaultdict
+
+
+LOG_PATTERN = re.compile(
+    r"\[AI_STEP\].*?step=(?P<step>[a-zA-Z0-9_./:-]+).*?elapsedMs=(?P<elapsed>\d+)"
+)
+
+
+def parse_log(file_path: str):
+    stats = defaultdict(list)
+
+    with open(file_path, "r", encoding="utf-8", errors="ignore") as file:
+        for line in file:
+            match = LOG_PATTERN.search(line)
+            if not match:
+                continue
+
+            step = match.group("step")
+            elapsed = int(match.group("elapsed"))
+            stats[step].append(elapsed)
+
+    return stats
+
+
+def print_summary(stats):
+    if not stats:
+        print("No [AI_STEP] logs found.")
+        return
+
+    rows = []
+
+    for step, values in stats.items():
+        count = len(values)
+        avg = sum(values) / count
+        max_value = max(values)
+        min_value = min(values)
+
+        rows.append((step, count, avg, max_value, min_value))
+
+    rows.sort(key=lambda x: x[2], reverse=True)
+
+    print()
+    print("AI_STEP Summary")
+    print("-" * 80)
+    print(f"{'step':35} {'count':>8} {'avg(ms)':>12} {'max(ms)':>12} {'min(ms)':>12}")
+    print("-" * 80)
+
+    for step, count, avg, max_value, min_value in rows:
+        print(f"{step:35} {count:8d} {avg:12.2f} {max_value:12d} {min_value:12d}")
+
+    print("-" * 80)
+
+
+def main():
+    file_path = sys.argv[1] if len(sys.argv) > 1 else "logs/fastapi.log"
+    stats = parse_log(file_path)
+    print_summary(stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/summary_mcp_tools.py
+++ b/scripts/summary_mcp_tools.py
@@ -1,0 +1,63 @@
+import re
+import sys
+from collections import defaultdict
+
+
+LOG_PATTERN = re.compile(
+    r"\[MCP_TOOL\].*?tool=(?P<tool>[a-zA-Z0-9_./:-]+).*?elapsedMs=(?P<elapsed>\d+)"
+)
+
+
+def parse_log(file_path: str):
+    stats = defaultdict(list)
+
+    with open(file_path, "r", encoding="utf-8", errors="ignore") as file:
+        for line in file:
+            match = LOG_PATTERN.search(line)
+            if not match:
+                continue
+
+            tool = match.group("tool")
+            elapsed = int(match.group("elapsed"))
+            stats[tool].append(elapsed)
+
+    return stats
+
+
+def print_summary(stats):
+    if not stats:
+        print("No [MCP_TOOL] logs found.")
+        return
+
+    rows = []
+
+    for tool, values in stats.items():
+        count = len(values)
+        avg = sum(values) / count
+        max_value = max(values)
+        min_value = min(values)
+
+        rows.append((tool, count, avg, max_value, min_value))
+
+    rows.sort(key=lambda x: x[2], reverse=True)
+
+    print()
+    print("MCP_TOOL Summary")
+    print("-" * 80)
+    print(f"{'tool':35} {'count':>8} {'avg(ms)':>12} {'max(ms)':>12} {'min(ms)':>12}")
+    print("-" * 80)
+
+    for tool, count, avg, max_value, min_value in rows:
+        print(f"{tool:35} {count:8d} {avg:12.2f} {max_value:12d} {min_value:12d}")
+
+    print("-" * 80)
+
+
+def main():
+    file_path = sys.argv[1] if len(sys.argv) > 1 else "logs/mcp.log"
+    stats = parse_log(file_path)
+    print_summary(stats)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #56

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

AI 응답 지연 측정 결과를 반복적으로 확인할 수 있도록 로그 요약 스크립트를 추가했습니다.

- FastAPI `[AI_STEP]` 로그 요약 스크립트 추가
- MCP `[MCP_TOOL]` 로그 요약 스크립트 추가
- `/ai/order/start`로 세션 생성 후 `/ai/order/chat`을 반복 호출하는 성능 테스트 스크립트 추가
- FastAPI/MCP 로그 요약 통합 실행 스크립트 추가
- `logs/`, `*.log` Git 추적 제외 설정 추가

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

이번 작업은 성능 개선이 아니라 측정 자동화 작업입니다.

기존에는 `/ai/order/chat` 요청 후 FastAPI 로그와 MCP 로그를 직접 확인해야 했지만, 이제 로그 파일 기준으로 step/tool별 `count`, `avg`, `max`, `min` 값을 자동으로 확인할 수 있습니다.

테스트 결과 `/ai/order/chat` 1회 요청 기준 전체 처리 시간은 약 9.2초였고, `langgraph_invoke` 구간이 약 9.1초로 대부분을 차지했습니다. 반면 MCP Tool 호출인 `tool_get_top_menus`는 평균 약 43ms 수준으로 확인되어, 현재 병목은 MCP Tool 호출이 아니라 LangGraph 내부 AI Agent 실행 구간으로 판단됩니다.

또한 일부 노드 로그에서 `requestId=None`이 확인되었습니다. 현재 요약에는 문제 없지만, 추후 요청 단위로 더 정확히 추적하려면 LangGraph 내부 노드까지 `request_id` 전달 범위를 보완할 필요가 있습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

Postman 대신 로컬 성능 테스트 스크립트로 검증했습니다.

```bash
COUNT=1 bash scripts/perf_test_chat.sh
bash scripts/run_perf_summary.sh