### PR TITLE
[Fix] 담기 완료 알림 시 menu_options 후처리 주입 방지

### DIFF
--- a/service/graph/nodes/order_node.py
+++ b/service/graph/nodes/order_node.py
@@ -275,6 +275,11 @@ def _patch_menu_options(messages: list) -> list:
     )
     current_turn = messages[last_human_idx + 1:]
 
+    # 마지막 사용자 메시지가 프론트 담기 완료 알림이면 후처리 스킵
+    last_human = messages[last_human_idx] if last_human_idx >= 0 else None
+    if last_human and "장바구니에 담겼어" in (last_human.content or ""):
+        return messages
+
     menu_detail: dict | None = None
     cart_add_result: dict | None = None
     selected_option_ids: list[int] = []


### PR DESCRIPTION


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
프론트가 "X 장바구니에 담겼어" 메시지를 보낼 때 _patch_menu_options가
tool_get_menu_detail 결과를 보고 menu_options를 강제 주입하는 문제 수정. reply 텍스트 대신 사용자 메시지를 기준으로 완료 알림 여부를 판단해 안정성 개선.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
