### PR TITLE
[Docs] README — 이현노 작업/역할 상세 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 # 2. Team Members (팀원 및 팀 소개)
 | 조효동 | 이현노 | 임현우 | 임호영 |
 |:------:|:------:|:------:|:------:|
-| <img src="https://github.com/hyodongg.png" alt="효동" width="150"> | <img src="https://github.com/identicons/placeholder.png" alt="이현노" width="150"> | <img src="https://github.com/identicons/placeholder.png" alt="임현우" width="150"> | <img src="https://github.com/identicons/placeholder.png" alt="임호영" width="150"> |
-| BE / AI | BE | FE | FE |
+| <img src="https://github.com/hyodongg.png" alt="효동" width="150"> | <img src="https://github.com/leehyunro123.png" alt="현노" width="150"> | <img src="https://github.com/identicons/placeholder.png" alt="임현우" width="150"> | <img src="https://github.com/identicons/placeholder.png" alt="임호영" width="150"> |
+| BE / AI | AI · 음성플로우 | FE | FE |
 | [GitHub](https://github.com/hyodongg) | [GitHub](https://github.com/leehyunro123) | [GitHub](https://github.com/sexybugmaster) | [GitHub](https://github.com/pyeree) |
 
 
@@ -134,6 +134,7 @@ LangGraph로 구성된 상태 기반 에이전트입니다. 노드 단위로 의
 |  |  |  |
 |--------|--------|--------|
 | 조효동 | <img src="https://github.com/hyodongg.png" alt="효동" width="100"> | <ul><li>FastAPI AI 서버 설계 및 개발</li><li>LangGraph 주문 에이전트 구현 (모드별 행동 지침 분리)</li><li>MCP Tool 설계 및 구현</li><li>Smithery MCP 서버 배포 및 연동</li></ul> |
+| 이현노 | <img src="https://github.com/leehyunro123.png" alt="현노" width="100"> | <ul><li><b>음성 원격조작 응답 채널(action)</b> 및 clarify 의도 분기·노드 UI 지침 구현</li><li><b>일반 모드 전용 프롬프트(_NORMAL_MODE_GUIDE)</b> 설계 — 화면 제어/주문 플로우 지침</li><li><b>의도 분류 튜닝</b> — 날씨→추천 라우팅, 메뉴 문의→order, 주문 확인 완료→payment, 단순 인사 처리</li><li>결제 노드 화면 안내 전환 및 추천·응답 파싱 보완</li></ul> |
 
 <br/>
 <br/>


### PR DESCRIPTION
## 📣 Related Issue
- close #

## 📝 Summary

README 의 **팀원 소개(섹션 2)** · **역할 분담(섹션 4)** 에 **이현노** 기여 내용을 상세 기재했습니다.
다른 팀원 항목은 변경하지 않았습니다. (문서 변경만 — 코드 영향 없음)

**섹션 2 (Team Members)**
- 프로필 이미지 placeholder → 실제 GitHub 아바타(`github.com/leehyunro123.png`)
- 역할 `BE` → `AI · 음성플로우`

**섹션 4 (Tasks & Responsibilities) — 이현노 작업 상세 추가**
- **음성 원격조작 응답 채널(action)** 및 clarify 의도 분기·노드 UI 지침 구현
- **일반 모드 전용 프롬프트(`_NORMAL_MODE_GUIDE`)** 설계 — 화면 제어/주문 플로우 지침
- **의도 분류 튜닝** — 날씨→추천 라우팅, 메뉴 문의→order, 주문 확인 완료→payment, 단순 인사 처리
- 결제 노드 화면 안내 전환 및 추천·응답 파싱 보완

## 🙏 Question & PR point
- 문서 변경만 있습니다. 역할 표기/문구만 검토 부탁드립니다.

## 📬 Postman
- 해당 없음 (문서 변경)
